### PR TITLE
Revert "Feat: set linguist language of typst source files"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto *.typ linguist-language=rust


### PR DESCRIPTION
Reverts Myriad-Dreamin/typst.ts#39

Wrong gitattributes format.
