### PR TITLE
fix(svg): always include clip path & style in svg

### DIFF
--- a/exporter/svg/src/render/incremental.rs
+++ b/exporter/svg/src/render/incremental.rs
@@ -96,12 +96,14 @@ impl SvgExporter {
 
         // attach the glyph defs, clip paths, and style defs
         svg.push("<defs>".into());
+        svg.push("<g>".into());
         svg.extend(new_glyphs);
+        svg.push("</g>".into());
+
+        Self::clip_paths(t.clip_paths, &mut svg);
         svg.push("</defs>".into());
 
-        // incremental style
-        svg.push(r#"<style type="text/css" data-reuse="1">"#.into());
-        svg.push("</style>".into());
+        Self::style_defs(t.style_defs, &mut svg);
 
         // body
         svg.append(&mut svg_body);


### PR DESCRIPTION
另外之前好像忘记给glyph套一个` <g>` 了，这次一并加上