### PR TITLE
feat: Page-level Partial Rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,6 +3863,7 @@ dependencies = [
  "once_cell",
  "path-clean",
  "rkyv",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_with",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,7 @@ byteorder.workspace = true
 base64-serde = "0.7.0"
 
 once_cell.workspace = true
+rustc-hash.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true

--- a/core/src/vector/ir.rs
+++ b/core/src/vector/ir.rs
@@ -319,7 +319,7 @@ pub struct TextShape {
 pub struct TransformedItem(pub TransformItem, pub Box<SvgItem>);
 
 /// Absolute positioning items at their corresponding points.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct GroupItem(pub Vec<(Point, SvgItem)>);
 
 /// Item representing all the transform that is applicable to a [`SvgItem`].

--- a/core/src/vector/ir.rs
+++ b/core/src/vector/ir.rs
@@ -361,7 +361,7 @@ pub type GlyphPack = Vec<(AbsoluteRef, GlyphItem)>;
 pub struct GlyphPackBuilder;
 
 impl GlyphPackBuilder {
-    pub fn finalize(glyphs: GlyphMapping) -> GlyphPack {
+    pub fn finalize(glyphs: impl IntoIterator<Item = (GlyphItem, AbsoluteRef)>) -> GlyphPack {
         let mut glyphs = glyphs.into_iter().collect::<Vec<_>>();
         glyphs.sort_by(|(_, a), (_, b)| a.id.0.cmp(&b.id.0));
         glyphs.into_iter().map(|(a, b)| (b, a)).collect()

--- a/exporter/svg/src/backend/mod.rs
+++ b/exporter/svg/src/backend/mod.rs
@@ -415,7 +415,7 @@ impl<
             + DynExportFeature,
     > FlatGroupContext<C> for SvgTextBuilder
 {
-    fn render_item_ref_at(&mut self, ctx: &mut C, pos: crate::ir::Point, item: &AbsoluteRef) {
+    fn render_item_ref_at(&mut self, ctx: &mut C, pos: crate::ir::Point, item: &Fingerprint) {
         let translate_attr = format!("translate({:.3},{:.3})", pos.x.0, pos.y.0);
 
         let sub_content = ctx.render_flat_item(item);
@@ -461,7 +461,7 @@ impl<
         self
     }
 
-    fn with_reuse(mut self, _ctx: &mut C, v: &AbsoluteRef) -> Self {
+    fn with_reuse(mut self, _ctx: &mut C, v: &Fingerprint) -> Self {
         self.attributes.push(("data-reuse-from", v.as_svg_id("g")));
         self
     }
@@ -475,8 +475,8 @@ impl<'m, C: FlatIncrRenderVm<'m, Resultant = Arc<SvgTextNode>, Group = SvgTextBu
         &mut self,
         ctx: &mut C,
         pos: crate::ir::Point,
-        item: &AbsoluteRef,
-        prev_item: &AbsoluteRef,
+        item: &Fingerprint,
+        prev_item: &Fingerprint,
     ) {
         let content = if item == prev_item {
             vec![]

--- a/exporter/svg/src/frontend/context.rs
+++ b/exporter/svg/src/frontend/context.rs
@@ -155,24 +155,24 @@ impl<'m, 't, Feat: ExportFeature> FlatRenderVm<'m> for RenderContext<'m, 't, Fea
     type Resultant = Arc<SvgTextNode>;
     type Group = SvgTextBuilder;
 
-    fn get_item(&self, value: &AbsoluteRef) -> Option<&'m FlatSvgItem> {
+    fn get_item(&self, value: &Fingerprint) -> Option<&'m FlatSvgItem> {
         self.module.get_item(value)
     }
 
-    fn start_flat_group(&mut self, v: &AbsoluteRef) -> Self::Group {
+    fn start_flat_group(&mut self, v: &Fingerprint) -> Self::Group {
         Self::Group {
             attributes: vec![("data-tid", v.as_svg_id("g"))],
             content: Vec::with_capacity(1),
         }
     }
 
-    fn start_flat_frame(&mut self, value: &AbsoluteRef, _group: &GroupRef) -> Self::Group {
+    fn start_flat_frame(&mut self, value: &Fingerprint, _group: &GroupRef) -> Self::Group {
         let mut g = self.start_flat_group(value);
         g.attributes.push(("class", "typst-group".to_owned()));
         g
     }
 
-    fn start_flat_text(&mut self, value: &AbsoluteRef, text: &FlatTextItem) -> Self::Group {
+    fn start_flat_text(&mut self, value: &Fingerprint, text: &FlatTextItem) -> Self::Group {
         let mut g = self.start_flat_group(value);
         g.with_text_shape(self, &text.shape);
         g

--- a/exporter/svg/src/frontend/dynamic_layout.rs
+++ b/exporter/svg/src/frontend/dynamic_layout.rs
@@ -1,16 +1,19 @@
 use std::sync::Arc;
 
 use typst::doc::Document;
-use typst_ts_core::vector::{
-    flat_ir::{ModuleBuilder, MultiSvgDocument},
-    ir::{Abs, AbsoluteRef, GlyphMapping, Size},
-    LowerBuilder,
+use typst_ts_core::{
+    hash::Fingerprint,
+    vector::{
+        flat_ir::{ModuleBuilder, MultiSvgDocument},
+        ir::{Abs, GlyphMapping, Size},
+        LowerBuilder,
+    },
 };
 
 #[derive(Default)]
 pub struct DynamicLayoutSvgExporter {
     builder: ModuleBuilder,
-    layouts: Vec<(Abs, Vec<(AbsoluteRef, Size)>)>,
+    layouts: Vec<(Abs, Vec<(Fingerprint, Size)>)>,
 }
 
 impl DynamicLayoutSvgExporter {
@@ -25,7 +28,7 @@ impl DynamicLayoutSvgExporter {
             .iter()
             .map(|p| {
                 let abs_ref = self.builder.build(t.lower(p));
-                (abs_ref, p.size().into())
+                (abs_ref.fingerprint, p.size().into())
             })
             .collect::<Vec<_>>();
 
@@ -46,7 +49,7 @@ impl DynamicLayoutSvgExporter {
 
     pub fn debug_stat(&self) -> String {
         let v = self.builder.finalize_ref();
-        let item_cnt = v.0.item_pack.0.len();
+        let item_cnt = v.0.items.len();
         let glyph_cnt = v.1.len();
         let module_data = crate::flat_ir::serialize_module(v.0);
         format!(

--- a/exporter/svg/src/frontend/dynamic_layout.rs
+++ b/exporter/svg/src/frontend/dynamic_layout.rs
@@ -28,7 +28,7 @@ impl DynamicLayoutSvgExporter {
             .iter()
             .map(|p| {
                 let abs_ref = self.builder.build(t.lower(p));
-                (abs_ref.fingerprint, p.size().into())
+                (abs_ref, p.size().into())
             })
             .collect::<Vec<_>>();
 

--- a/exporter/svg/src/frontend/flat.rs
+++ b/exporter/svg/src/frontend/flat.rs
@@ -58,7 +58,7 @@ impl<Feat: ExportFeature> SvgExporter<Feat> {
             .iter()
             .map(|p| {
                 let abs_ref = builder.build(lower_builder.lower(p));
-                (abs_ref, p.size().into())
+                (abs_ref.fingerprint, p.size().into())
             })
             .collect::<Vec<_>>();
         let (module, glyph_mapping) = builder.finalize();

--- a/exporter/svg/src/frontend/flat.rs
+++ b/exporter/svg/src/frontend/flat.rs
@@ -58,7 +58,7 @@ impl<Feat: ExportFeature> SvgExporter<Feat> {
             .iter()
             .map(|p| {
                 let abs_ref = builder.build(lower_builder.lower(p));
-                (abs_ref.fingerprint, p.size().into())
+                (abs_ref, p.size().into())
             })
             .collect::<Vec<_>>();
         let (module, glyph_mapping) = builder.finalize();

--- a/exporter/svg/src/frontend/incremental.rs
+++ b/exporter/svg/src/frontend/incremental.rs
@@ -162,7 +162,7 @@ impl IncrementalSvgExporter {
                             (builder.source_mapping.len() - 1) as u64,
                         ));
                     }
-                    (abs_ref.fingerprint, p.size().into())
+                    (abs_ref, p.size().into())
                 })
                 .collect::<Vec<_>>();
             let (module, glyph_mapping) = builder.finalize_ref();

--- a/exporter/svg/src/frontend/incremental_v2.rs
+++ b/exporter/svg/src/frontend/incremental_v2.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use typst::doc::Document;
 use typst_ts_core::vector::{
     flat_ir::{
-        build_flat_glyphs, serialize_module_v2, IncrModuleBuilder, Module, ModuleMetadata, Pages,
-        SerializedModule, SourceMappingNode, SvgDocument,
+        build_flat_glyphs, serialize_module_v2, IncrModuleBuilder, ItemPack, Module,
+        ModuleMetadata, Pages, SerializedModule, SourceMappingNode, SvgDocument,
     },
     ir::Scalar,
     LowerBuilder,
@@ -63,7 +63,7 @@ impl IncrementalSvgV2Exporter {
                         (builder.source_mapping.len() - 1) as u64,
                     ));
                 }
-                (abs_ref, p.size().into())
+                (abs_ref.fingerprint, p.size().into())
             })
             .collect::<Vec<_>>();
         let (module, glyph_mapping) = builder.finalize_delta();
@@ -77,7 +77,7 @@ impl IncrementalSvgV2Exporter {
                 ModuleMetadata::GarbageCollection(gc_items),
             ],
             glyphs,
-            item_pack: module.item_pack,
+            item_pack: ItemPack(module.items.clone().into_iter().collect()),
             layouts: vec![(Scalar(0.), pages.clone())],
         });
 
@@ -96,7 +96,7 @@ impl IncrementalSvgV2Exporter {
                 ModuleMetadata::PageSourceMapping(vec![self.page_source_mapping.clone()]),
             ],
             glyphs,
-            item_pack: doc.module.item_pack.clone(),
+            item_pack: ItemPack(doc.module.items.clone().into_iter().collect()),
             layouts: vec![(Scalar(0.), doc.pages.clone())],
         });
         Some([b"diff-v1,", delta.as_slice()].concat())

--- a/exporter/svg/src/frontend/incremental_v2.rs
+++ b/exporter/svg/src/frontend/incremental_v2.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+
+use typst::doc::Document;
+use typst_ts_core::vector::{
+    flat_ir::{
+        build_flat_glyphs, serialize_module_v2, IncrModuleBuilder, Module, ModuleMetadata, Pages,
+        SerializedModule, SourceMappingNode, SvgDocument,
+    },
+    ir::Scalar,
+    LowerBuilder,
+};
+
+use crate::{backend::SvgText, ExportFeature, IncrementalRenderContext, SvgExporter, SvgTask};
+
+/// The feature set which is used for exporting incremental rendered svg.
+struct IncrementalExportFeature;
+
+impl ExportFeature for IncrementalExportFeature {
+    const ENABLE_TRACING: bool = false;
+    const SHOULD_ATTACH_DEBUG_INFO: bool = false;
+    const SHOULD_RENDER_TEXT_ELEMENT: bool = true;
+    const USE_STABLE_GLYPH_ID: bool = true;
+    const WITH_BUILTIN_CSS: bool = false;
+    const WITH_RESPONSIVE_JS: bool = false;
+    const AWARE_HTML_ENTITY: bool = true;
+}
+
+#[derive(Default)]
+pub struct IncrementalSvgV2Exporter {
+    prev: Option<SvgDocument>,
+    module_builder: IncrModuleBuilder,
+    page_source_mapping: Vec<SourceMappingNode>,
+
+    should_attach_debug_info: bool,
+}
+
+impl IncrementalSvgV2Exporter {
+    pub fn set_should_attach_debug_info(&mut self, should_attach_debug_info: bool) {
+        self.module_builder.should_attach_debug_info = should_attach_debug_info;
+        self.should_attach_debug_info = should_attach_debug_info;
+    }
+
+    pub fn pack_delta(&mut self, output: Arc<Document>) -> Vec<u8> {
+        self.module_builder.reset();
+        self.page_source_mapping.clear();
+
+        let instant: std::time::Instant = std::time::Instant::now();
+
+        self.module_builder.increment_lifetime();
+
+        // it is important to call gc before building pages
+        let gc_items = self.module_builder.gc(120);
+
+        let mut lower_builder = LowerBuilder::new(&output);
+        let builder = &mut self.module_builder;
+        let pages = output
+            .pages
+            .iter()
+            .map(|p| {
+                let abs_ref = builder.build(lower_builder.lower(p));
+                if self.should_attach_debug_info {
+                    self.page_source_mapping.push(SourceMappingNode::Page(
+                        (builder.source_mapping.len() - 1) as u64,
+                    ));
+                }
+                (abs_ref, p.size().into())
+            })
+            .collect::<Vec<_>>();
+        let (module, glyph_mapping) = builder.finalize_delta();
+
+        let glyphs = build_flat_glyphs(glyph_mapping);
+
+        let delta = serialize_module_v2(&SerializedModule {
+            metadata: vec![
+                ModuleMetadata::SourceMappingData(module.source_mapping),
+                ModuleMetadata::PageSourceMapping(vec![self.page_source_mapping.clone()]),
+                ModuleMetadata::GarbageCollection(gc_items),
+            ],
+            glyphs,
+            item_pack: module.item_pack,
+            layouts: vec![(Scalar(0.), pages.clone())],
+        });
+
+        println!("svg render time (incremental bin): {:?}", instant.elapsed());
+
+        [b"diff-v1,", delta.as_slice()].concat()
+    }
+
+    pub fn pack_current(&mut self) -> Option<Vec<u8>> {
+        let doc = self.prev.as_ref()?;
+        let glyphs = build_flat_glyphs(self.module_builder.glyphs.clone());
+
+        let delta = serialize_module_v2(&SerializedModule {
+            metadata: vec![
+                ModuleMetadata::SourceMappingData(self.module_builder.source_mapping.clone()),
+                ModuleMetadata::PageSourceMapping(vec![self.page_source_mapping.clone()]),
+            ],
+            glyphs,
+            item_pack: doc.module.item_pack.clone(),
+            layouts: vec![(Scalar(0.), doc.pages.clone())],
+        });
+        Some([b"diff-v1,", delta.as_slice()].concat())
+    }
+
+    pub fn render_in_window(module: &Module, prev: Option<Pages>, next: &Pages) -> String {
+        type IncrExporter = SvgExporter<IncrementalExportFeature>;
+
+        let mut svg = Vec::<SvgText>::new();
+        svg.push(SvgText::Plain(IncrExporter::header(next)));
+        let mut svg_body = vec![];
+
+        // render the document
+        let mut t = SvgTask::<IncrementalExportFeature>::default();
+
+        let prev = prev.unwrap_or_default();
+        let render_context = IncrementalRenderContext {
+            module,
+            prev: &prev,
+            next,
+        };
+        t.render_diff(&render_context, &mut svg_body);
+
+        // todo: render glyphs
+        // svg.push(r#"<defs class="glyph">"#.into());
+        // svg.extend(new_glyphs);
+        // svg.push("</defs>".into());
+
+        // attach the clip paths, and style defs
+
+        svg.push(r#"<defs class="clip-path">"#.into());
+        IncrExporter::clip_paths(t.clip_paths, &mut svg);
+        svg.push("</defs>".into());
+
+        IncrExporter::style_defs(t.style_defs, &mut svg);
+
+        // body
+        svg.append(&mut svg_body);
+
+        svg.push("</svg>".into());
+
+        let mut string_io = String::new();
+        string_io.reserve(svg.iter().map(SvgText::estimated_len).sum());
+        for s in svg {
+            s.write_string_io(&mut string_io);
+        }
+
+        string_io
+    }
+}

--- a/exporter/svg/src/frontend/incremental_v2.rs
+++ b/exporter/svg/src/frontend/incremental_v2.rs
@@ -63,7 +63,7 @@ impl IncrementalSvgV2Exporter {
                         (builder.source_mapping.len() - 1) as u64,
                     ));
                 }
-                (abs_ref.fingerprint, p.size().into())
+                (abs_ref, p.size().into())
             })
             .collect::<Vec<_>>();
         let (module, glyph_mapping) = builder.finalize_delta();

--- a/exporter/svg/src/frontend/mod.rs
+++ b/exporter/svg/src/frontend/mod.rs
@@ -23,6 +23,9 @@ pub(crate) mod flat;
 #[cfg(feature = "flat-vector")]
 pub(crate) mod incremental;
 pub use incremental::{IncrementalRenderContext, IncrementalSvgExporter};
+#[cfg(feature = "flat-vector")]
+pub(crate) mod incremental_v2;
+pub use incremental_v2::IncrementalSvgV2Exporter;
 
 use crate::{
     backend::{SvgGlyphBuilder, SvgText, SvgTextNode},

--- a/exporter/svg/src/lib.rs
+++ b/exporter/svg/src/lib.rs
@@ -26,7 +26,10 @@ pub use backend::SvgGlyphBuilder;
 /// the document.
 pub(crate) mod frontend;
 #[cfg(feature = "flat-vector")]
-pub use frontend::{DynamicLayoutSvgExporter, IncrementalRenderContext, IncrementalSvgExporter};
+pub use frontend::{
+    DynamicLayoutSvgExporter, IncrementalRenderContext, IncrementalSvgExporter,
+    IncrementalSvgV2Exporter,
+};
 pub use frontend::{SvgExporter, SvgTask};
 
 /// Useful transform for SVG Items.

--- a/packages/renderer/src/lib.rs
+++ b/packages/renderer/src/lib.rs
@@ -82,7 +82,9 @@ impl SvgSession {
                 typst_ts_svg_exporter::flat_ir::ModuleMetadata::PageSourceMapping(data) => {
                     self.page_source_mappping = data;
                 }
-                _ => {}
+                typst_ts_svg_exporter::flat_ir::ModuleMetadata::GarbageCollection(data) => {
+                    crate::utils::console_log!("garbage collection counts: {:?}", data.len());
+                }
             }
         }
         Ok(())

--- a/packages/typst.ts/src/main.ts
+++ b/packages/typst.ts/src/main.ts
@@ -9,7 +9,7 @@ export type {
 export { preloadRemoteFonts, preloadSystemFonts } from './options.init';
 import * as renderer from './renderer';
 export type { TypstRenderer } from './renderer';
-export { createTypstRenderer } from './renderer';
+export { createTypstRenderer, createTypstSvgRenderer } from './renderer';
 import { RenderView, renderTextLayer } from './view';
 import * as compiler from './compiler';
 import { FetchAccessModel } from './fs';

--- a/packages/typst.ts/src/renderer.ts
+++ b/packages/typst.ts/src/renderer.ts
@@ -164,9 +164,9 @@ class TypstRendererSvgDriver {
     this.renderer = await buildComponent(options, gRendererModule, typst.TypstRendererBuilder, {});
   }
 
-  createModule(b: Uint8Array): Promise<unknown> {
+  createModule(b?: Uint8Array): Promise<unknown> {
     return new Promise(resolve => {
-      resolve(this.renderer.create_svg_session(b));
+      resolve(b ? this.renderer.create_svg_session(b) : this.renderer.create_empty_svg_session());
     });
   }
 


### PR DESCRIPTION
Record left work here, also records todos in typst-preview.

Before taking todo list, Iet us illustrate incremental svg exporter with partial rendering feature here.
First, `IncrementalSvgExporter::render_svg_incremental` is replaced by `IncrementalSvgV2Exporter::pack_svg_delta`, which does following simple algorithm.
```rust
fn pack_svg_delta(&mut self, typst_doc: Doc) -> Vec<u8> {
  self.lifetime += 1;
  // it is important to call gc before building pages
  let gc_items = self.module_builder.gc(120 /* lifetime delta */);
  // build delta
  let (pages, module, glyphs) = self.module_builder.build_delta(typst_doc);
  // serialization
  let delta_binary = create_delta_binary({
    source_mapping: self.module_builder.source_mapping, // all of the source mapping data
    garbage_collection: gc_items // these items should be removed in client side.
    pages, module, glyphs, // regular data
  });
  return [b"diff-v1,", delta.as_slice()].concat()
}
```

Next, moving to client side, we accumulate the delta information so simply get a complete SVG document as same as the server-side one, $S = \sum_i \Delta S_i$.

Then, we retrieve the bounding rectangle of user's window $W$, to intersect the complete SVG document $S$ and render a differential svg description. There are three different forked method here:
+ $W = \infty$, hence the partial rendering is disabled, then we get the incremental SVG exporter working like the older implementation.
+ estimate **pages** to rendering by page's bbox, then we get a page-level partial rendering.
+ estimate **items** to rendering by item's bbox, then we get a item-level partial rendering.
This step corresponds to the function `SvgSession::render_in_window` in https://github.com/Myriad-Dreamin/typst.ts/tree/binary-incr-svg/packages/renderer.
```rust
fn render_in_window(&mut self, 
  mut user_bbox: Option<Rect>, should_cmp_item_level: bool) -> String {
  user_bbox = user_bbox.unwrap_or_else(Rect::MAX);
  let prev_state = self.prev_state.take();
  let res = String::default();
  for page in self.pages {
    if page not in user_bbox { continue } // page-level partial rendering
    for items in page {
      if should_cmp_item_level and item not in user_bbox { continue } // item-level partial rendering
      res = differential_render(res, prev_state, item);
    }
  }
  return res;
}
```

Finally, the `res` string is compatible to the previous `diff-v0` format, we patch DOM and then get a desired DOM.

Server side:

- [x] remove `DefId` references from the struct `FlatSvgItem`. They prevent graceful GC algorithms (optional).
- [x] implement a `comemo` like GC, see `self.module_builder.gc` in first step (optional).
- <del>reimplement unstable id reference to glyphs in `exporter/svg/lib/minifier/mod.rs` (optional).</del>
- [ ] replace `IncrementalSvgExporter` by `v2` (optional).
- [ ] refactor code (optional).

Client side:
- [x] make a global svg which stores glyph data.
- [x] implement page-level partial rendering.
- <del>verify items' bbox calculation (optional).</del>
- <del>implement item-level partial rendering (optional).</del>
- [x] add more tests.
  - [x] test pku thesis template.
  - [x] test masterproef.

