### PR TITLE
fix(exporter::svg): missing quote in stroke dasharray

### DIFF
--- a/exporter/svg/src/backend/mod.rs
+++ b/exporter/svg/src/backend/mod.rs
@@ -535,7 +535,7 @@ fn render_path(path: &ir::PathItem) -> SvgText {
                 p.push(format!(r#"stroke-miterlimit="{}" "#, limit.0));
             }
             PathStyle::StrokeDashArray(array) => {
-                p.push(r#"stroke-dasharray="#.to_owned());
+                p.push(r#"stroke-dasharray=""#.to_owned());
                 for (i, v) in array.iter().enumerate() {
                     if i > 0 {
                         p.push(" ".to_owned());


### PR DESCRIPTION
```
#import "@preview/showybox:1.1.0": showybox
#showybox(
  title-style: (
    color: black
  ),
  frame: (
    title-color: rgb(236, 243, 255),
    border-color: rgb(0x44, 0x8a, 0xff),
    thickness: (left: 1cm)
  ),
  title: "Hello world! - An example",
  [
    Hello world!
  ]
)
```