### PR TITLE
dev(compiler): use fontdb to load system fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,12 +1076,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
 name = "fontdb"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
 dependencies = [
+ "fontconfig-parser",
  "log",
+ "memmap2",
  "slotmap",
  "tinyvec",
  "ttf-parser",
@@ -1991,9 +2002,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memmap2"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
 dependencies = [
  "libc",
 ]
@@ -4233,19 +4244,20 @@ dependencies = [
  "dissimilar",
  "ecow",
  "flate2",
+ "fontdb",
  "fst",
  "hex",
  "indexmap 2.0.2",
  "instant",
  "js-sys",
  "log",
- "memmap2",
  "nohash-hasher",
  "notify",
  "once_cell",
  "parking_lot",
  "pathdiff",
  "pollster",
+ "rayon",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ tokio-tungstenite = "0.20.0"
 
 # system
 dirs = "5"
+fontdb = "0.15.0"                                          # "0.15.0"
 memmap2 = "0.9"
 notify = "6"
 path-clean = "1.0.1"
@@ -223,3 +224,5 @@ hayagriva = { git = "https://github.com/Myriad-Dreamin/hayagriva.git", branch = 
 # typst-syntax = { path = "../typst/crates/typst-syntax" }
 # typst-ide = { path = "../typst/crates/typst-ide" }
 # hayagriva = { path = "../hayagriva" }
+
+# fontdb = { path = "../fontdb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ tokio-tungstenite = "0.20.0"
 
 # system
 dirs = "5"
-fontdb = "0.15.0"                                          # "0.15.0"
+fontdb = "0.15.0"
 memmap2 = "0.9"
 notify = "6"
 path-clean = "1.0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,6 +41,7 @@ human-panic.workspace = true
 typst-ts-core.workspace = true
 typst-ts-compiler = { workspace = true, default-features = false, features = [
     "system",
+    # "lazy-fontdb",
     "dynamic-layout",
 ] }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -194,7 +194,6 @@ fn measure_fonts(args: MeasureFontsArgs) -> ! {
 
     let world = TypstSystemWorld::new(CompileOpts {
         root_dir: root_path,
-        font_profile_paths,
         font_paths: args.font.paths,
         font_profile_cache_path: args.output.clone(),
         no_system_fonts: args.no_system_fonts,

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,18 +24,20 @@ flate2.workspace = true
 ecow.workspace = true
 instant.workspace = true
 strum.workspace = true
+rayon.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true
 serde-wasm-bindgen = { workspace = true, optional = true }
 
-memmap2 = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 pollster = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+fontdb = { workspace = true, optional = true }
+
 chrono = { workspace = true }
 base64.workspace = true
 rustc-hash.workspace = true
@@ -85,12 +87,13 @@ serde.workspace = true
 [features]
 cjk = []
 emoji = []
+lazy-fontdb = []
 system-compile = [
-    "dep:memmap2",
     "dep:dirs",
     "dep:walkdir",
     "dep:notify",
     "dep:log",
+    "dep:fontdb",
 ]
 system-watch = ["dep:notify", "dep:tokio"]
 system = ["system-compile", "system-watch"]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,7 +24,7 @@ flate2.workspace = true
 ecow.workspace = true
 instant.workspace = true
 strum.workspace = true
-rayon.workspace = true
+rayon = { workspace = true, optional = true }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -87,7 +87,7 @@ serde.workspace = true
 [features]
 cjk = []
 emoji = []
-lazy-fontdb = []
+lazy-fontdb = ["dep:rayon"]
 system-compile = [
     "dep:dirs",
     "dep:walkdir",

--- a/compiler/src/system.rs
+++ b/compiler/src/system.rs
@@ -54,23 +54,23 @@ impl TypstSystemWorld {
             if path.is_dir() {
                 searcher.search_dir(&path);
             } else {
-                searcher.search_file(&path);
+                let _ = searcher.search_file(&path);
             }
         }
         // Source2: add the fonts from system paths.
         if !opts.no_system_fonts {
             searcher.search_system();
         }
+
+        // flush source1 and source2 before adding source3
+        searcher.flush();
+
         // Source3: add the fonts in memory.
         for font_data in opts.with_embedded_fonts {
             searcher.add_memory_font(match font_data {
                 Cow::Borrowed(data) => Bytes::from_static(data),
                 Cow::Owned(data) => Bytes::from(data),
             });
-        }
-        // Source4: add the fonts from the profile cache.
-        for profile_path in opts.font_profile_paths {
-            searcher.add_profile_by_path(&profile_path);
         }
 
         Ok(searcher.into())

--- a/core/src/config/compiler.rs
+++ b/core/src/config/compiler.rs
@@ -15,10 +15,6 @@ pub struct CompileOpts {
     /// Path to entry
     pub entry: PathBuf,
 
-    /// Path to font profiles
-    #[serde(rename = "fontProfilePaths")]
-    pub font_profile_paths: Vec<PathBuf>,
-
     /// Path to font profile for cache
     #[serde(rename = "fontProfileCachePath")]
     pub font_profile_cache_path: PathBuf,
@@ -30,10 +26,6 @@ pub struct CompileOpts {
     /// Exclude system font paths
     #[serde(rename = "noSystemFonts")]
     pub no_system_fonts: bool,
-
-    /// Exclude vanilla font paths
-    #[serde(rename = "noVanillaFonts")]
-    pub no_vanilla_fonts: bool,
 
     /// Include embedded fonts
     #[serde(rename = "withEmbeddedFonts")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,8 @@
 // Core type system/concepts of typst-ts.
+// #![warn(missing_docs)]
+// #![warn(missing_debug_implementations)]
+// #![warn(missing_copy_implementations)]
+
 pub(crate) mod concepts;
 pub use concepts::*;
 pub mod error;


### PR DESCRIPTION
https://github.com/typst/typst/pull/2472

Also add some more ease-to-use font cache strategy (disabled by default) since we noticed worse performance on loading cjk fonts.
```log
Benchmark 1: typst compile .\fuzzers\corpora\math\main.typ
  Time (mean ± σ):     473.9 ms ±  50.3 ms    [User: 31.2 ms, System: 18.8 ms]
  Range (min … max):   423.1 ms … 563.6 ms    10 runs

Benchmark 2: typst-ts-cli compile --entry "fuzzers/corpora/math/main.typ" --format pdf
  Time (mean ± σ):      73.0 ms ±   4.0 ms    [User: 6.0 ms, System: 11.2 ms]
  Range (min … max):    67.1 ms …  85.3 ms    39 runs

Summary
  typst-ts-cli compile --entry "fuzzers/corpora/math/main.typ" --format pdf ran
    6.49 ± 0.78 times faster than typst compile .\fuzzers\corpora\math\main.typ
```