### PR TITLE
feat: export diagnostics objects

### DIFF
--- a/crates/reflexo/src/debug_loc.rs
+++ b/crates/reflexo/src/debug_loc.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use serde::{Deserialize, Serialize};
 
 /// A serializable physical position in a document.
@@ -42,12 +44,18 @@ pub struct FileLocation {
 /// A char position represented in form of line and column.
 /// The position is encoded in Utf-8 or Utf-16, and the encoding is
 /// determined by usage.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 pub struct CharPosition {
     /// The line number, starting at 0.
     pub line: usize,
     /// The column number, starting at 0.
     pub column: usize,
+}
+
+impl fmt::Display for CharPosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.line, self.column)
+    }
 }
 
 impl From<Option<(usize, usize)>> for CharPosition {
@@ -93,10 +101,20 @@ pub struct FlatSourceLocation {
 // /// A resolved file range.
 // ///
 // /// See [`CharPosition`] for the definition of the position inside a file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CharRange {
     pub start: CharPosition,
     pub end: CharPosition,
+}
+
+impl fmt::Display for CharRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.start == self.end {
+            write!(f, "{}", self.start)
+        } else {
+            write!(f, "{}-{}", self.start, self.end)
+        }
+    }
 }
 
 // /// A resolved source (text) range.

--- a/crates/reflexo/src/error.rs
+++ b/crates/reflexo/src/error.rs
@@ -14,13 +14,13 @@ pub enum DiagSeverity {
     Hint = 4,
 }
 
-impl ToString for DiagSeverity {
-    fn to_string(&self) -> String {
+impl fmt::Display for DiagSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DiagSeverity::Error => "error".to_string(),
-            DiagSeverity::Warning => "warning".to_string(),
-            DiagSeverity::Information => "information".to_string(),
-            DiagSeverity::Hint => "hint".to_string(),
+            DiagSeverity::Error => write!(f, "error"),
+            DiagSeverity::Warning => write!(f, "warning"),
+            DiagSeverity::Information => write!(f, "information"),
+            DiagSeverity::Hint => write!(f, "hint"),
         }
     }
 }

--- a/packages/typst.node/src/error.rs
+++ b/packages/typst.node/src/error.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use napi_derive::napi;
 use std::{cell::OnceCell, fmt::Write, sync::Arc};
 use typst_ts_core::{
-    error::{diag_from_std, prelude::WithContext, TypstSourceDiagnostic},
+    error::{long_diag_from_std, prelude::WithContext, TypstSourceDiagnostic},
     typst::prelude::*,
     TypstDocument, TypstWorld,
 };
@@ -104,7 +104,7 @@ impl NodeError {
         world: Option<&dyn TypstWorld>,
     ) -> napi::Result<Vec<serde_json::Value>, NodeError> {
         self.get_diagnostics()
-            .map(move |e| diag_from_std(e, world))
+            .flat_map(move |e| long_diag_from_std(e, world))
             .map(serde_json::to_value)
             .collect::<Result<_, _>>()
             .context("failed to serialize diagnostics")

--- a/packages/typst.ts/scripts/fix-cjs.mjs
+++ b/packages/typst.ts/scripts/fix-cjs.mjs
@@ -31,8 +31,9 @@ walk('./dist/cjs', (path) => {
         // only replace (require("*.mjs")) to (require("*.cjs"))
         // and  replace (from "*.mjs") to (from "*.cjs")
         const newContent = content
-            .replace(/Promise\s*\.\s*resolve\s*\(\s*\)\s*\.\s*then\s*\(\s*\(\s*\)\s*=>\s*require\(['"](.*)['"]\)\s*\)/g, 'import("$1")')
-        .replace(/require\(\s*['"](.*)\.mjs['"]\s*\)/g, 'require("$1.cjs")').replace(/from\s*['"](.*)\.mjs['"]/g, 'from "$1.cjs"');
+        .replace(/Promise\s*\.\s*resolve\s*\(\s*\)\s*\.\s*then\s*\(\s*\(\s*\)\s*=>\s*require\(['"](.*?)['"]\)\s*\)/g, 'import("$1")')
+        .replace(/import\(\s*['"].\/(.*?)\.mjs['"]\s*\)/g, 'import(".\/$1.cjs")')
+        .replace(/require\(\s*['"](.*?)\.mjs['"]\s*\)/g, 'require("$1.cjs")').replace(/from\s*['"](.*?)\.mjs['"]/g, 'from "$1.cjs"');
         writeFileSync(newPath, newContent);
     }
 });

--- a/packages/typst.ts/src/contrib/snippet.mts
+++ b/packages/typst.ts/src/contrib/snippet.mts
@@ -380,7 +380,10 @@ export class TypstSnippet {
    */
   async vector(o?: SweetCompileOptions) {
     const opts = await this.getCompileOptions(o);
-    return (await this.getCompiler()).compile(opts).finally(() => this.removeTmp(opts));
+    return (await this.getCompiler())
+      .compile(opts)
+      .then(res => res.result)
+      .finally(() => this.removeTmp(opts));
   }
 
   /**
@@ -390,7 +393,10 @@ export class TypstSnippet {
   async pdf(o?: SweetCompileOptions) {
     const opts = await this.getCompileOptions(o);
     opts.format = 'pdf';
-    return (await this.getCompiler()).compile(opts).finally(() => this.removeTmp(opts));
+    return (await this.getCompiler())
+      .compile(opts)
+      .then(res => res.result)
+      .finally(() => this.removeTmp(opts));
   }
 
   /**
@@ -458,17 +464,19 @@ export class TypstSnippet {
       .finally(() => this.removeTmp(opts));
   }
 
-  private async getCompileOptions(opts?: SweetCompileOptions): Promise<CompileOptions> {
+  private async getCompileOptions(
+    opts?: SweetCompileOptions,
+  ): Promise<CompileOptions<any, 'none'>> {
     if (opts === undefined) {
-      return { mainFilePath: this.mainFilePath };
+      return { mainFilePath: this.mainFilePath, diagnostics: 'none' };
     } else if (typeof opts === 'string') {
       throw new Error(`please specify opts as {mainContent: '...'} or {mainFilePath: '...'}`);
     } else if ('mainFilePath' in opts) {
-      return { ...opts };
+      return { ...opts, diagnostics: 'none' };
     } else {
       const destFile = `/tmp/${randstr()}.typ`;
       await this.addSource(destFile, opts.mainContent);
-      return { mainFilePath: destFile };
+      return { mainFilePath: destFile, diagnostics: 'none' };
     }
   }
 
@@ -478,7 +486,10 @@ export class TypstSnippet {
     }
 
     const opts = await this.getCompileOptions(o);
-    return (await this.getCompiler()).compile(opts).finally(() => this.removeTmp(opts));
+    return (await this.getCompiler())
+      .compile(opts)
+      .then(res => res.result!)
+      .finally(() => this.removeTmp(opts));
   }
 
   private async transientRender<T>(

--- a/templates/node.js-compiler-next/src/main.ts
+++ b/templates/node.js-compiler-next/src/main.ts
@@ -1,6 +1,6 @@
 // test import
-import * as _1 from '@myriaddreamin/typst-ts-renderer';
-import * as _2 from '@myriaddreamin/typst-ts-web-compiler';
+// import * as _1 from '@myriaddreamin/typst-ts-renderer';
+// import * as _2 from '@myriaddreamin/typst-ts-web-compiler';
 
 import {
   createTypstCompiler,
@@ -12,25 +12,50 @@ async function main() {
   const compiler = createTypstCompiler();
   await compiler.init(await cachedFontInitOptions());
 
-  compiler.addSource('/main.typ', 'Hello, typst!');
-  const artifactData = await compiler.compile({
-    mainFilePath: '/main.typ',
-  });
+  {
+    compiler.addSource('/main.typ', 'Hello, typst!');
+    const artifactData = (
+      await compiler.compile({
+        mainFilePath: '/main.typ',
+        diagnostics: 'unix',
+      })
+    ).result!;
 
-  const renderer = createTypstRenderer();
-  await renderer.init();
-  const svg = await renderer.runWithSession(async session => {
-    renderer.manipulateData({
-      renderSession: session,
-      action: 'reset',
-      data: artifactData,
+    const renderer = createTypstRenderer();
+    await renderer.init();
+    const svg = await renderer.runWithSession(async session => {
+      renderer.manipulateData({
+        renderSession: session,
+        action: 'reset',
+        data: artifactData,
+      });
+      return renderer.renderSvg({
+        renderSession: session,
+      });
     });
-    return renderer.renderSvg({
-      renderSession: session,
-    });
-  });
 
-  console.log('Renderer works exactly! The rendered SVG file:', svg.length);
+    console.log('Renderer works exactly! The rendered SVG file:', svg.length);
+  }
+
+  {
+    compiler.addSource(
+      '/main.typ',
+      `
+
+
+ #`,
+    );
+    const artifactData = await compiler.compile({
+      mainFilePath: '/main.typ',
+      diagnostics: 'unix',
+    });
+
+    if (!artifactData.diagnostics?.length) {
+      throw new Error("Renderer doesn't produce diags exactly..");
+    }
+
+    console.log('Renderer produces diags exactly! The diagnostics is', artifactData.diagnostics);
+  }
 }
 
 main();


### PR DESCRIPTION
This PR *is not a breaking change* at runtime, but enforces you to use new API signature by type checking at compile time. 

https://github.com/Myriad-Dreamin/typst.ts/blob/826166768c36e0860b6340ce28eddbefa9475ef3/packages/typst.ts/src/compiler.mts#L96-L102

This type checking will be removed in v0.6.0.

The only changed API is following:

https://github.com/Myriad-Dreamin/typst.ts/blob/826166768c36e0860b6340ce28eddbefa9475ef3/packages/typst.ts/src/compiler.mts#L176-L190
