### PR TITLE
fix: dom viewport width calculation

### DIFF
--- a/packages/typst.ts/src/contrib/dom/typst-doc.mts
+++ b/packages/typst.ts/src/contrib/dom/typst-doc.mts
@@ -15,6 +15,7 @@ export interface ContainerDOMState {
   boundingRect: {
     left: number;
     top: number;
+    right: number;
   };
 }
 
@@ -119,6 +120,7 @@ export class TypstDocumentContext<O = any> {
     boundingRect: {
       left: 0,
       top: 0,
+      right: 0,
     },
   };
 

--- a/packages/typst.ts/src/dom.mts
+++ b/packages/typst.ts/src/dom.mts
@@ -140,11 +140,11 @@ export function provideDomDoc<TBase extends GConstructor<TypstDocumentContext<In
 
     getDomViewport(
       cachedWindow: Pick<Window, 'innerHeight' | 'innerWidth'>,
-      cachedBoundingRect: Pick<DOMRect, 'left' | 'top'>,
+      cachedBoundingRect: Pick<DOMRect, 'left' | 'top' | 'right'>,
     ) {
       const left = cachedBoundingRect.left;
       const top = -cachedBoundingRect.top;
-      const right = cachedWindow.innerWidth;
+      const right = cachedBoundingRect.right;
       const bottom = cachedWindow.innerHeight - cachedBoundingRect.top;
       const rect = {
         x: 0,


### PR DESCRIPTION
Fix for the calculation of the right boundary of dom viewport. Use `cachedBoundingRect.right` rather then `cachedWindow.innerWidth`.