### PR TITLE
chore: expose wasm file in compiler, renderer, parser package

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -9,12 +9,14 @@
     "Typst"
   ],
   "type": "module",
+  "module": "./pkg/wasm-pack-shim.mjs",
+  "types": "./pkg/typst_ts_web_compiler.d.ts",
   "exports": {
     ".": {
-      "module": "pkg/wasm-pack-shim.mjs",
-      "types": "pkg/typst_ts_web_compiler.d.ts"
+      "module": "./pkg/wasm-pack-shim.mjs",
+      "types": "./pkg/typst_ts_web_compiler.d.ts"
     },
-    "./wasm": "pkg/typst_ts_web_compiler_bg.wasm"
+    "./wasm": "./pkg/typst_ts_web_compiler_bg.wasm"
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -9,8 +9,13 @@
     "Typst"
   ],
   "type": "module",
-  "module": "pkg/wasm-pack-shim.mjs",
-  "types": "pkg/typst_ts_web_compiler.d.ts",
+  "exports": {
+    ".": {
+      "module": "pkg/wasm-pack-shim.mjs",
+      "types": "pkg/typst_ts_web_compiler.d.ts"
+    },
+    "./wasm": "pkg/typst_ts_web_compiler_bg.wasm"
+  },
   "files": [
     "pkg/wasm-pack-shim.mjs",
     "pkg/typst_ts_web_compiler_bg.wasm",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -9,12 +9,14 @@
     "Typst"
   ],
   "type": "module",
+  "module": "./pkg/wasm-pack-shim.mjs",
+  "types": "./pkg/typst_ts_parser.d.ts",
   "exports": {
     ".": {
-      "module": "pkg/wasm-pack-shim.mjs",
-      "types": "pkg/typst_ts_parser.d.ts"
+      "module": "./pkg/wasm-pack-shim.mjs",
+      "types": "./pkg/typst_ts_parser.d.ts"
     },
-    "./wasm": "pkg/typst_ts_parser_bg.wasm"
+    "./wasm": "./pkg/typst_ts_parser_bg.wasm"
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -9,8 +9,13 @@
     "Typst"
   ],
   "type": "module",
-  "module": "pkg/wasm-pack-shim.mjs",
-  "types": "pkg/typst_ts_parser.d.ts",
+  "exports": {
+    ".": {
+      "module": "pkg/wasm-pack-shim.mjs",
+      "types": "pkg/typst_ts_parser.d.ts"
+    },
+    "./wasm": "pkg/typst_ts_parser_bg.wasm"
+  },
   "files": [
     "pkg/wasm-pack-shim.mjs",
     "pkg/typst_ts_parser_bg.wasm",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -9,12 +9,14 @@
     "Typst"
   ],
   "type": "module",
+  "module": "./pkg/wasm-pack-shim.mjs",
+  "types": "./pkg/typst_ts_renderer.d.ts",
   "exports": {
     ".": {
-      "module": "pkg/wasm-pack-shim.mjs",
-      "types": "pkg/typst_ts_renderer.d.ts"
+      "module": "./pkg/wasm-pack-shim.mjs",
+      "types": "./pkg/typst_ts_renderer.d.ts"
     },
-    "./wasm": "pkg/typst_ts_renderer_bg.wasm"
+    "./wasm": "./pkg/typst_ts_renderer_bg.wasm"
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -9,8 +9,13 @@
     "Typst"
   ],
   "type": "module",
-  "module": "pkg/wasm-pack-shim.mjs",
-  "types": "pkg/typst_ts_renderer.d.ts",
+  "exports": {
+    ".": {
+      "module": "pkg/wasm-pack-shim.mjs",
+      "types": "pkg/typst_ts_renderer.d.ts"
+    },
+    "./wasm": "pkg/typst_ts_renderer_bg.wasm"
+  },
   "files": [
     "pkg/wasm-pack-shim.mjs",
     "pkg/typst_ts_renderer_bg.wasm",

--- a/packages/typst.solid/demo/package.json
+++ b/packages/typst.solid/demo/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@myriaddreamin/typst-ts-renderer": "0.5.5-rc7",
     "@myriaddreamin/typst.ts": "0.5.5-rc7",
-    "solid-devtools": "^0.29.3",
+    "solid-devtools": "^0.34.0",
     "typescript": "^5.6.2",
     "vite": "^6.2.3",
     "vite-plugin-solid": "^2.11.6"

--- a/packages/typst.ts/src/compiler.mts
+++ b/packages/typst.ts/src/compiler.mts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import type * as typst from '@myriaddreamin/typst-ts-web-compiler/pkg/wasm-pack-shim.mjs';
+import type * as typst from '@myriaddreamin/typst-ts-web-compiler';
 import { buildComponent, globalFontPromises } from './init.mjs';
 import { FsAccessModel, SemanticTokens, SemanticTokensLegend, kObject } from './internal.types.mjs';
 
@@ -288,7 +288,7 @@ export interface TypstCompiler {
 }
 
 const gCompilerModule = new LazyWasmModule(async (bin?: any) => {
-  const module = await import('@myriaddreamin/typst-ts-web-compiler/pkg/wasm-pack-shim.mjs');
+  const module = await import('@myriaddreamin/typst-ts-web-compiler');
   return await module.default(bin);
 });
 
@@ -315,7 +315,7 @@ class TypstCompilerDriver {
   constructor() {}
 
   async init(options?: Partial<InitOptions>): Promise<void> {
-    this.compilerJs = await import('@myriaddreamin/typst-ts-web-compiler/pkg/wasm-pack-shim.mjs');
+    this.compilerJs = await import('@myriaddreamin/typst-ts-web-compiler');
     const TypstCompilerBuilder = this.compilerJs.TypstCompilerBuilder;
 
     const compilerOptions = { ...(options || {}) };

--- a/packages/typst.ts/src/renderer.mts
+++ b/packages/typst.ts/src/renderer.mts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import type * as typst from '@myriaddreamin/typst-ts-renderer/pkg/wasm-pack-shim.mjs';
+import type * as typst from '@myriaddreamin/typst-ts-renderer';
 
 import type { InitOptions } from './options.init.mjs';
 import { PageInfo, RenderCanvasResult, TypstDefaultParams, kObject } from './internal.types.mjs';
@@ -611,7 +611,7 @@ export function createTypstSvgRenderer(): TypstSvgRenderer {
 }
 
 export async function rendererBuildInfo(): Promise<any> {
-  const renderModule = await import('@myriaddreamin/typst-ts-renderer/pkg/wasm-pack-shim.mjs');
+  const renderModule = await import('@myriaddreamin/typst-ts-renderer');
   return renderModule.renderer_build_info();
 }
 
@@ -626,7 +626,7 @@ export class TypstRendererDriver {
 
   async init(options?: Partial<InitOptions>): Promise<void> {
     this.rendererJs = await (options?.getWrapper?.() ||
-      import('@myriaddreamin/typst-ts-renderer/pkg/wasm-pack-shim.mjs'));
+      import('@myriaddreamin/typst-ts-renderer'));
     const TypstRendererBuilder = this.rendererJs.TypstRendererBuilder;
     this.renderer = await buildComponent(
       options,


### PR DESCRIPTION
I tried to use typst.ts directly (without typst.react) in a vite + react app.
Since there's only `nodeJsImportWasmModule` in the shim file, I got a Error in browser.

After some looking around, the right way is to pass in a url or a wasm module in `getModule()`.
Since the wasm file itself isn't exposed, there's really no way to get a url without using some other vite plugins.

Maybe we should expose wasm files directly, so we can do something like:

```ts
import wasmUrl from '@myriaddreamin/typst-ts-web-compiler/wasm?url';

const cc = createTypstCompiler();
await cc.init({
  getModule: () => wasmUrl
});
```