### PR TITLE
fix: make consistent variable name in binary input example documentation

### DIFF
--- a/docs/cookery/guide/all-in-one-inputs.typ
+++ b/docs/cookery/guide/all-in-one-inputs.typ
@@ -25,19 +25,19 @@ With extra *binary input files*:
 ```ts
 const encoder = new TextEncoder();
 // add a json file (utf8)
-compiler.mapShadow('/assets/data.json', encoder.encode(jsonData));
+$typst.mapShadow('/assets/data.json', encoder.encode(jsonData));
 // remove a json file
-compiler.unmapShadow('/assets/data.json');
+$typst.unmapShadow('/assets/data.json');
 
 // add an image file
 const pngData = await fetch(...).arrayBuffer();
-compiler.mapShadow('/assets/tiger.png', new Uint8Array(pngData));
+$typst.mapShadow('/assets/tiger.png', new Uint8Array(pngData));
 ```
 
 clean up shadow files for underlying access model:
 
 ```ts
-compiler.resetShadow();
+$typst.resetShadow();
 ```
 
 Note: this function will also clean all files added by `addSource`.


### PR DESCRIPTION
This PR addresses an inconsistency in the documentation example for "With extra binary input files" found at [[1.1. All-in-one (Simplified) Library for Browsers](https://myriad-dreamin.github.io/typst.ts/cookery/guide/all-in-one.html)](https://myriad-dreamin.github.io/typst.ts/cookery/guide/all-in-one.html)

The example uses a `compiler` variable for methods like `mapShadow`, while other examples consistently use the `$typst` object for similar operations (e.g., `addSource`, `vector`). This difference can be confusing for users.

This change replaces `compiler` with `$typst` to align with the other examples.
