### PR TITLE
test: fix and test exports of packages

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -13,11 +13,13 @@
   "types": "./pkg/typst_ts_web_compiler.d.ts",
   "exports": {
     ".": {
-      "node": "./pkg/wasm-pack-shim.mjs",
-      "module": "./pkg/wasm-pack-shim.mjs",
-      "types": "./pkg/typst_ts_web_compiler.d.ts"
+      "types": "./pkg/typst_ts_web_compiler.d.ts",
+      "default": "./pkg/wasm-pack-shim.mjs"
     },
-    "./wasm": "./pkg/typst_ts_web_compiler_bg.wasm"
+    "./wasm": {
+      "types": "./pkg/typst_ts_web_compiler_bg.wasm.d.ts",
+      "default": "./pkg/typst_ts_web_compiler_bg.wasm"
+    }
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -10,13 +10,17 @@
   ],
   "type": "module",
   "module": "./pkg/wasm-pack-shim.mjs",
+  "require": "./pkg/wasm-pack-shim.mjs",
   "types": "./pkg/typst_ts_parser.d.ts",
   "exports": {
     ".": {
-      "module": "./pkg/wasm-pack-shim.mjs",
-      "types": "./pkg/typst_ts_parser.d.ts"
+      "types": "./pkg/typst_ts_parser.d.ts",
+      "default": "./pkg/wasm-pack-shim.mjs"
     },
-    "./wasm": "./pkg/typst_ts_parser_bg.wasm"
+    "./wasm": {
+      "types": "./pkg/typst_ts_parser_bg.wasm.d.ts",
+      "default": "./pkg/typst_ts_parser_bg.wasm"
+    }
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -14,11 +14,13 @@
   "types": "./pkg/typst_ts_renderer.d.ts",
   "exports": {
     ".": {
-      "node": "./pkg/wasm-pack-shim.mjs",
-      "module": "./pkg/wasm-pack-shim.mjs",
-      "types": "./pkg/typst_ts_renderer.d.ts"
+      "types": "./pkg/typst_ts_renderer.d.ts",
+      "default": "./pkg/wasm-pack-shim.mjs"
     },
-    "./wasm": "./pkg/typst_ts_renderer_bg.wasm"
+    "./wasm": {
+      "types": "./pkg/typst_ts_renderer_bg.wasm.d.ts",
+      "default": "./pkg/typst_ts_renderer_bg.wasm"
+    }
   },
   "files": [
     "pkg/wasm-pack-shim.mjs",

--- a/packages/typst.ts/package.json
+++ b/packages/typst.ts/package.json
@@ -23,7 +23,7 @@
         "default": "./dist/cjs/index.cjs"
       },
       "import": {
-        "types": "./dist/esm/index.d.ts",
+        "types": "./dist/esm/index.d.mts",
         "default": "./dist/esm/index.mjs"
       }
     },
@@ -317,7 +317,7 @@
     "prepublish": "turbo build",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
-    "test:e2e": "node scripts/test-templates.mjs",
+    "test:e2e": "node scripts/test-templates.mjs && node scripts/test-imports.mjs",
     "publish:dry": "npm publish --dry-run --access public",
     "publish:lib": "npm publish --access public || exit 0",
     "test-install": "yarn playwright install-deps && yarn playwright install"
@@ -342,6 +342,7 @@
     "@myriaddreamin/typst-ts-web-compiler": "*",
     "@types/web": "^0.0.188",
     "builtin-modules": "3.3.0",
+    "resolve.exports": "2.0.3",
     "tslib": "2.5.2"
   }
 }

--- a/packages/typst.ts/scripts/test-imports.mjs
+++ b/packages/typst.ts/scripts/test-imports.mjs
@@ -1,0 +1,58 @@
+import * as resolve from 'resolve.exports';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+for (const pkgName of ['typst.ts', 'renderer', 'compiler', 'parser', 'typst.react', 'typst.vue3']) {
+  const pkgDir = join(import.meta.dirname, '../..', pkgName);
+  const pkgPath = join(pkgDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath));
+  if (!pkg.exports) {
+    console.log(`No exports found for ${pkgName}`);
+    continue;
+  }
+  const validExports = Object.keys(pkg.exports).filter(key => !key.includes('*'));
+
+  for (const key of validExports) {
+    for (const conditions of [
+      ['require'],
+      // declarations
+      ['require', 'types'],
+      ['require', 'node'],
+      ['require', 'browser'],
+      // vite
+      ['require', 'browser', 'production'],
+
+      ['module', 'import'],
+      // declarations
+      ['module', 'import', 'types'],
+      ['module', 'import', 'node'],
+      ['module', 'import', 'browser'],
+      // vite
+      ['module', 'import', 'browser', 'production'],
+    ]) {
+      for (const unsafe of [false, true]) {
+        try {
+          const exportPath = resolve.exports(pkg, key, { conditions, unsafe });
+          if (conditions.includes('types') && exportPath && !exportPath[0].endsWith('ts')) {
+            throw new Error(
+              `This is not a types export for ${pkgName} ${key} with conditions ${conditions} and unsafe ${unsafe}:`,
+            );
+          }
+          for (const p of exportPath || []) {
+            const exportAbsPath = join(pkgDir, p);
+            if (!existsSync(exportAbsPath)) {
+              throw new Error(
+                `This export does not exist in filesystem for ${pkgName} ${key} with conditions ${conditions} and unsafe ${unsafe}: ${p}`,
+              );
+            }
+          }
+        } catch (error) {
+          console.error(
+            `Error resolving export for ${pkgName} ${key} with conditions ${conditions} and unsafe ${unsafe}:`,
+          );
+          throw error;
+        }
+      }
+    }
+  }
+}

--- a/packages/typst.ts/scripts/test-imports.mjs
+++ b/packages/typst.ts/scripts/test-imports.mjs
@@ -14,18 +14,24 @@ for (const pkgName of ['typst.ts', 'renderer', 'compiler', 'parser', 'typst.reac
 
   for (const key of validExports) {
     for (const conditions of [
+      // commonjs
       ['require'],
-      // declarations
+      // commonjs type declarations
       ['require', 'types'],
+      // commonjs node
       ['require', 'node'],
+      // commonjs browser
       ['require', 'browser'],
       // vite
       ['require', 'browser', 'production'],
 
+      // esm
       ['module', 'import'],
-      // declarations
+      // esm type declarations
       ['module', 'import', 'types'],
+      // esm node
       ['module', 'import', 'node'],
+      // esm browser
       ['module', 'import', 'browser'],
       // vite
       ['module', 'import', 'browser', 'production'],

--- a/packages/typst.ts/scripts/transform.mjs
+++ b/packages/typst.ts/scripts/transform.mjs
@@ -51,7 +51,7 @@ const generatedExports = {
       default: './dist/cjs/index.cjs',
     },
     import: {
-      types: './dist/esm/index.d.ts',
+      types: './dist/esm/index.d.mts',
       default: './dist/esm/index.mjs',
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6991,11 +6991,6 @@ human-signals@^5.0.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 hyperdyperid@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
@@ -9860,6 +9855,11 @@ resolve-url-loader@5.0.0:
     loader-utils "^2.0.0"
     postcss "^8.2.14"
     source-map "0.6.1"
+
+resolve.exports@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
+  integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
 resolve@1.22.10, resolve@^1.14.2, resolve@^1.22.4:
   version "1.22.10"


### PR DESCRIPTION
I got errors when building typst.ts with typst-preview (that previewer for tinymist). I investigated vite and find `resolve.exports` that help us catch all of the incorrect `exports` fields of packages. I had only added tests for:
+ packages: `['typst.ts', 'renderer', 'compiler', 'parser', 'typst.react', 'typst.vue3']`
+ conditions:
    ```js
  // commonjs
  ['require'],
  // commonjs type declarations
  ['require', 'types'],
  // commonjs node
  ['require', 'node'],
  // commonjs browser
  ['require', 'browser'],
  // vite (the tinymist got errors with this condition)
  ['require', 'browser', 'production'],

  // esm
  ['module', 'import'],
  // esm type declarations
  ['module', 'import', 'types'],
  // esm node
  ['module', 'import', 'node'],
  // esm browser
  ['module', 'import', 'browser'],
  // vite (the tinymist got errors with this condition)
  ['module', 'import', 'browser', 'production'],
    ```
 
 @c0per 
    