### PR TITLE
test: break change for v0.6.0 and test vectors to build

### DIFF
--- a/packages/typst.ts/src/compiler.all.test.mts
+++ b/packages/typst.ts/src/compiler.all.test.mts
@@ -67,6 +67,30 @@ describe('compiler creations', () => {
       getModule: getModule().compiler,
     });
   });
+  it('should success with good vector', async () => {
+    const compiler = createTypstCompiler();
+    await compiler.init({
+      beforeBuild: [disableDefaultFontAssets()],
+      getModule: getModule().compiler,
+    });
+    await compiler.addSource('/main.typ', 'Hello, world!');
+    const data = await compiler.compile({
+      mainFilePath: '/main.typ',
+    });
+    expect(data.result?.length).toMatchInlineSnapshot(`368`);
+  });
+  it('should success with good vector', async () => {
+    const compiler = createTypstCompiler();
+    await compiler.init({
+      beforeBuild: [disableDefaultFontAssets()],
+      getModule: getModule().compiler,
+    });
+    await compiler.addSource('/main.typ', '= A bit different!');
+    const data = await compiler.compile({
+      mainFilePath: '/main.typ',
+    });
+    expect(data.result?.length).toMatchInlineSnapshot(`376`);
+  });
 });
 
 describe('snippet compiler', () => {

--- a/packages/typst.ts/src/compiler.mts
+++ b/packages/typst.ts/src/compiler.mts
@@ -86,7 +86,7 @@ interface TransientCompileOptions<
   format?: F;
   /**
    * Whether to include diagnostic information in the result.
-   * Note: it will be set to true by default in v0.6.0
+   * Note: it will be set to 'full' by default in v0.6.0
    * @default 'full'
    */
   diagnostics?: Diagnostics;

--- a/packages/typst.ts/src/compiler.mts
+++ b/packages/typst.ts/src/compiler.mts
@@ -87,9 +87,9 @@ interface TransientCompileOptions<
   /**
    * Whether to include diagnostic information in the result.
    * Note: it will be set to true by default in v0.6.0
-   * @default undefined
+   * @default 'full'
    */
-  diagnostics: Diagnostics;
+  diagnostics?: Diagnostics;
 }
 
 interface IncrementalCompileOptions<Diagnostics extends DiagnosticsFormat = DiagnosticsFormat>
@@ -107,9 +107,9 @@ interface IncrementalCompileOptions<Diagnostics extends DiagnosticsFormat = Diag
    * Whether to include diagnostic information in the result.
    * Note: Before v0.6.0, when diagnostics is not set, the result will be a Uint8Array.
    * After v0.6.0, when diagnostics is not set, the result will be a CompileResult<Uint8Array> without diagnostics.
-   * @default false
+   * @default 'full'
    */
-  diagnostics: Diagnostics;
+  diagnostics?: Diagnostics;
 }
 
 export interface QueryOptions extends CompileOptionsCommon {
@@ -467,8 +467,7 @@ function getDiagnosticsArg(diagnostics: string | undefined): number {
     case 'unix':
       return 2;
     case 'full':
-      return 3;
     default:
-      return 0;
+      return 3;
   }
 }


### PR DESCRIPTION
`diagnostics` will be set to `full` by default in v0.6.0.