### PR TITLE
build: bump version to 0.6.0-rc1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.5.md
+++ b/CHANGELOG/CHANGELOG-0.5.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "tinymist" extension will be documented in this file.
+All notable changes to the reflexo and "@myriaddreamin/\*typst\*" packages will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/CHANGELOG/CHANGELOG-0.6.md
+++ b/CHANGELOG/CHANGELOG-0.6.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## v0.6.0 - [2025-04-30]
 
+The v0.5.5 was not released because typst v0.13.0 comes before the v0.5.5 release, so we decided to skip it. The next release will be v0.6.0.
+
 - feat: upgrade typst to v0.13.0 in https://github.com/Myriad-Dreamin/typst.ts/pull/643
 - feat: update assets to v0.13.1 in https://github.com/Myriad-Dreamin/typst.ts/pull/682
 

--- a/CHANGELOG/CHANGELOG-0.6.md
+++ b/CHANGELOG/CHANGELOG-0.6.md
@@ -8,7 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 The v0.5.5 was not released because typst v0.13.0 comes before the v0.5.5 release, so we decided to skip it. The next release will be v0.6.0.
 
-- feat: upgrade typst to v0.13.0 in https://github.com/Myriad-Dreamin/typst.ts/pull/643
+- feat: upgrade typst to v0.13.1 in https://github.com/Myriad-Dreamin/typst.ts/pull/643 and https://github.com/Myriad-Dreamin/typst.ts/pull/661
 - feat: update assets to v0.13.1 in https://github.com/Myriad-Dreamin/typst.ts/pull/682
 
 ### Compiler

--- a/CHANGELOG/CHANGELOG-0.6.md
+++ b/CHANGELOG/CHANGELOG-0.6.md
@@ -1,0 +1,68 @@
+# Change Log
+
+All notable changes to the reflexo and "@myriaddreamin/\*typst\*" packages will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## v0.6.0 - [2025-04-30]
+
+- feat: upgrade typst to v0.13.0 in https://github.com/Myriad-Dreamin/typst.ts/pull/643
+- feat: update assets to v0.13.1 in https://github.com/Myriad-Dreamin/typst.ts/pull/682
+
+### Compiler
+
+- feat: use world implementation from tinymist in https://github.com/Myriad-Dreamin/typst.ts/pull/636
+- build: remove web-time in https://github.com/Myriad-Dreamin/typst.ts/pull/664
+  - This allows to use as a typst plugin
+
+### Renderer
+
+- feat: render labels on content in https://github.com/Myriad-Dreamin/typst.ts/pull/638
+  - `#box() <label>` will render the label attribute to the rendered elements.
+- feat: support image rendering attr in https://github.com/Myriad-Dreamin/typst.ts/pull/659
+  - https://typst.app/docs/reference/visualize/image/#parameters-scaling
+
+### Packages
+
+- fix: update bad imports in https://github.com/Myriad-Dreamin/typst.ts/pull/680
+- fix: better node.js wasm import in https://github.com/Myriad-Dreamin/typst.ts/pull/700
+- feat: add style.css to enhanced-typst-svg bundle by @seven-mile in https://github.com/Myriad-Dreamin/typst.ts/pull/632
+- feat: expose wasm file in compiler, renderer, parser package by @c0per and @Myriad-Dreamin in https://github.com/Myriad-Dreamin/typst.ts/pull/662, https://github.com/Myriad-Dreamin/typst.ts/pull/674, https://github.com/Myriad-Dreamin/typst.ts/pull/693, and https://github.com/Myriad-Dreamin/typst.ts/pull/699
+
+### Package: vite-plugin-typst (New)
+
+- feat: init vite-plugin-typst in https://github.com/Myriad-Dreamin/typst.ts/pull/648
+- feat: add typst-cli option by @sjfhsjfh in https://github.com/Myriad-Dreamin/typst.ts/pull/650
+
+### Package: typst.ts
+
+- fix: load fonts and concurrency in https://github.com/Myriad-Dreamin/typst.ts/pull/701
+- test: add smoke tests in https://github.com/Myriad-Dreamin/typst.ts/pull/684
+- test: default compile options in https://github.com/Myriad-Dreamin/typst.ts/pull/702
+- test: break change for v0.6.0 and test vectors to build in https://github.com/Myriad-Dreamin/typst.ts/pull/704
+- feat: expose `$typst` in root in https://github.com/Myriad-Dreamin/typst.ts/pull/685
+
+### Package: typst.react
+
+- build: update react to v0.19 by @mrappard in https://github.com/Myriad-Dreamin/typst.ts/pull/672
+
+### Package: typst-ts-node-compiler
+
+- fix: reset read cache for node apis in https://github.com/Myriad-Dreamin/typst.ts/pull/683
+- test: confirm the creation_timestamp and pdf standard options are respected in https://github.com/Myriad-Dreamin/typst.ts/pull/696
+- feat: support PdfStandard `a-3b` in https://github.com/Myriad-Dreamin/typst.ts/pull/698
+
+### Misc
+
+- fix: typo in README.md by @kxxt in https://github.com/Myriad-Dreamin/typst.ts/pull/633
+- fix: make consistent variable name in binary input example documentation by @GaoCan702 in https://github.com/Myriad-Dreamin/typst.ts/pull/665
+- docs: rewrite get started in https://github.com/Myriad-Dreamin/typst.ts/pull/671
+- docs: rewrite rust service docs in https://github.com/Myriad-Dreamin/typst.ts/pull/673
+- docs: rewrite all-in-one js library docs in https://github.com/Myriad-Dreamin/typst.ts/pull/675
+- docs: improve wording of service.typ in https://github.com/Myriad-Dreamin/typst.ts/pull/676
+- docs: update get-started and all-in-one js docs in https://github.com/Myriad-Dreamin/typst.ts/pull/678
+- docs: alias index.html in https://github.com/Myriad-Dreamin/typst.ts/pull/689
+- docs: some broken links in docs in https://github.com/Myriad-Dreamin/typst.ts/pull/690
+- docs: lite bundle must load wasm files in https://github.com/Myriad-Dreamin/typst.ts/pull/703
+
+**Full Changelog**: https://github.com/Myriad-Dreamin/typst.ts/compare/v0.5.4...v0.6.0

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -8,4 +8,6 @@
 
 - [CHANGELOG-0.4.md](./CHANGELOG-0.4.md)
 
-- [CHANGELOG-0.4.md](./CHANGELOG-0.5.md)
+- [CHANGELOG-0.5.md](./CHANGELOG-0.5.md)
+
+- [CHANGELOG-0.6.md](./CHANGELOG-0.6.md)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "Run Typst in JavaScriptWorld."
 authors = ["Typst.ts Developers", "The Typst Project Developers"]
-version = "0.5.5-rc7"
+version = "0.6.0-rc1"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -205,21 +205,21 @@ tinymist-package = { version = "0.13.12-rc4", default-features = false }
 tinymist-project = { version = "0.13.12-rc4", default-features = false }
 
 # project core
-reflexo = { version = "0.5.5-rc7", path = "crates/reflexo", default-features = false }
-reflexo-typst = { version = "0.5.5-rc7", path = "crates/reflexo-typst" }
+reflexo = { version = "0.6.0-rc1", path = "crates/reflexo", default-features = false }
+reflexo-typst = { version = "0.6.0-rc1", path = "crates/reflexo-typst" }
 
 # conversions
-reflexo-typst2vec = { version = "0.5.5-rc7", path = "crates/conversion/typst2vec" }
-reflexo-vec2canvas = { version = "0.5.5-rc7", path = "crates/conversion/vec2canvas" }
-reflexo-vec2sema = { version = "0.5.5-rc7", path = "crates/conversion/vec2sema" }
-reflexo-vec2bbox = { version = "0.5.5-rc7", path = "crates/conversion/vec2bbox" }
-reflexo-vec2dom = { version = "0.5.5-rc7", path = "crates/conversion/vec2dom" }
-reflexo-vec2svg = { version = "0.5.5-rc7", path = "crates/conversion/vec2svg" }
+reflexo-typst2vec = { version = "0.6.0-rc1", path = "crates/conversion/typst2vec" }
+reflexo-vec2canvas = { version = "0.6.0-rc1", path = "crates/conversion/vec2canvas" }
+reflexo-vec2sema = { version = "0.6.0-rc1", path = "crates/conversion/vec2sema" }
+reflexo-vec2bbox = { version = "0.6.0-rc1", path = "crates/conversion/vec2bbox" }
+reflexo-vec2dom = { version = "0.6.0-rc1", path = "crates/conversion/vec2dom" }
+reflexo-vec2svg = { version = "0.6.0-rc1", path = "crates/conversion/vec2svg" }
 
 # project components
-typst-ts-test-common = { version = "0.5.5-rc7", path = "tests/common" }
-typst-ts-dev-server = { version = "0.5.5-rc7", path = "server/dev" }
-typst-ts-cli = { version = "0.5.5-rc7", path = "cli" }
+typst-ts-test-common = { version = "0.6.0-rc1", path = "tests/common" }
+typst-ts-dev-server = { version = "0.6.0-rc1", path = "server/dev" }
+typst-ts-cli = { version = "0.6.0-rc1", path = "cli" }
 
 [workspace.lints.rust]
 # missing_docs = "warn"

--- a/assets/data/bundle-size.json
+++ b/assets/data/bundle-size.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "sizes": {
     "typst-ts-renderer": 359580,
     "typst-ts-web-compiler": 7988658,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.ts",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "author": "Myriad-Dreamin",
   "description": "Run Typst in JavaScriptWorld.",
   "license": "Apache-2.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-web-compiler",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "WASM module for Compiling Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/enhanced-typst-svg/package.json
+++ b/packages/enhanced-typst-svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-typst-svg",
   "private": true,
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "Typst svg enhancement",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/ng/compiler/package.json
+++ b/packages/ng/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/reflexo-typst-compiler",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "Compile Typst documents in Browsers.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-parser",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "WASM module for Parsing Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-renderer",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "WASM module for rendering Typst documents in browser.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/typst.angular/package.json
+++ b/packages/typst.angular/package.json
@@ -27,8 +27,8 @@
     "zone.js": "~0.15.0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.5",

--- a/packages/typst.angular/projects/typst.angular/package.json
+++ b/packages/typst.angular/projects/typst.angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.angular",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "keywords": [
@@ -15,8 +15,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7"
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1"
   },
   "sideEffects": false
 }

--- a/packages/typst.node/npm/android-arm-eabi/package.json
+++ b/packages/typst.node/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-android-arm-eabi",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "android"
   ],

--- a/packages/typst.node/npm/android-arm64/package.json
+++ b/packages/typst.node/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-android-arm64",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "android"
   ],

--- a/packages/typst.node/npm/darwin-arm64/package.json
+++ b/packages/typst.node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-darwin-arm64",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "darwin"
   ],

--- a/packages/typst.node/npm/darwin-x64/package.json
+++ b/packages/typst.node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-darwin-x64",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "darwin"
   ],

--- a/packages/typst.node/npm/freebsd-x64/package.json
+++ b/packages/typst.node/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-freebsd-x64",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "freebsd"
   ],

--- a/packages/typst.node/npm/linux-arm-gnueabihf/package.json
+++ b/packages/typst.node/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm-gnueabihf",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-arm64-gnu/package.json
+++ b/packages/typst.node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm64-gnu",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-arm64-musl/package.json
+++ b/packages/typst.node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm64-musl",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-x64-gnu/package.json
+++ b/packages/typst.node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-x64-gnu",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-x64-musl/package.json
+++ b/packages/typst.node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-x64-musl",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/win32-arm64-msvc/package.json
+++ b/packages/typst.node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-win32-arm64-msvc",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "win32"
   ],

--- a/packages/typst.node/npm/win32-x64-msvc/package.json
+++ b/packages/typst.node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-win32-x64-msvc",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "os": [
     "win32"
   ],

--- a/packages/typst.node/package.json
+++ b/packages/typst.node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "author": "Myriad-Dreamin",
   "description": "Compile or Render Typst documents in Node environment.",
   "main": "index.js",

--- a/packages/typst.react/package.json
+++ b/packages/typst.react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.react",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "Typst.ts for React",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "publish:lib": "npm publish --access public || exit 0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
     "react": "^17.0.1 || ^18.x || ^19.x",
     "react-dom": "^17.0.1 || ^18.x || ^19.x"
   },

--- a/packages/typst.solid/demo/package.json
+++ b/packages/typst.solid/demo/package.json
@@ -9,8 +9,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "0.5.5-rc7",
+    "@myriaddreamin/typst-ts-renderer": "0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "0.6.0-rc1",
     "solid-devtools": "^0.34.0",
     "typescript": "^5.8.3",
     "vite": "^6.2.3",

--- a/packages/typst.solid/package.json
+++ b/packages/typst.solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.solid",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "A SolidJS package for Typst integration.",
   "type": "module",
   "exports": {
@@ -21,8 +21,8 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "0.5.5-rc7",
+    "@myriaddreamin/typst-ts-renderer": "0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "0.6.0-rc1",
     "solid-js": "^1.8.22",
     "vite-plugin-solid": "^2.11.6"
   },

--- a/packages/typst.ts/package.json
+++ b/packages/typst.ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.ts",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "Run Typst in JavaScriptWorld.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
@@ -326,8 +326,8 @@
     "idb": "^7.1.1"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-web-compiler": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.6.0-rc1"
   },
   "peerDependenciesMeta": {
     "@myriaddreamin/typst-ts-renderer": {

--- a/packages/typst.vue3/package.json
+++ b/packages/typst.vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.vue3",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "type": "module",
   "main": "src/Typst.vue",
   "scripts": {
@@ -10,8 +10,8 @@
     "publish:lib": "npm publish --access public || exit 0"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "0.6.0-rc1"
   },
   "peerDependencies": {
     "vue": "^3.4.31"

--- a/projects/hexo-renderer-typst/package.json
+++ b/projects/hexo-renderer-typst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-typst",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "Typst renderer plugin for Hexo",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
@@ -20,9 +20,9 @@
   },
   "peerDependencies": {
     "hexo": "^6",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-node-compiler": "^0.5.5-rc7"
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-node-compiler": "^0.6.0-rc1"
   },
   "devDependencies": {},
   "scripts": {

--- a/projects/highlighter/package.json
+++ b/projects/highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/highlighter-typst",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "typst code highlighting support in web",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
@@ -27,8 +27,8 @@
     "dist/**/*.{mts,mjs,cjs,cts,ts,js}"
   ],
   "peerDependencies": {
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-parser": "^0.5.5-rc7"
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-parser": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@myriaddreamin/typst.ts": "*",

--- a/projects/rehype-typst/package.json
+++ b/projects/rehype-typst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/rehype-typst",
-  "version": "0.5.5-rc7",
+  "version": "0.6.0-rc1",
   "description": "rehype plugin for rendering typst math equations",
   "main": "index.js",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "publish:lib": "npm publish --access public"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-node-compiler": "^0.5.5-rc7",
+    "@myriaddreamin/typst-ts-node-compiler": "^0.6.0-rc1",
     "@types/hast": "^3.0.0",
     "@types/katex": "^0.16.0",
     "hast-util-from-html-isomorphic": "^2.0.0",

--- a/templates/compiler-node/package.json
+++ b/templates/compiler-node/package.json
@@ -7,7 +7,7 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-node-compiler": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-node-compiler": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@types/node": "^20.6.3",

--- a/templates/compiler-wasm-cjs/package.json
+++ b/templates/compiler-wasm-cjs/package.json
@@ -7,9 +7,9 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-web-compiler": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
     "node-fetch": "3.3.2",
     "sync-request": "^6.1.0"
   },

--- a/templates/compiler-wasm-esm/package.json
+++ b/templates/compiler-wasm-esm/package.json
@@ -7,9 +7,9 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst-ts-web-compiler": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7",
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1",
     "node-fetch": "3.3.2",
     "sync-request": "^6.1.0"
   },

--- a/templates/renderer-wasm-cjs/package.json
+++ b/templates/renderer-wasm-cjs/package.json
@@ -7,8 +7,8 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@types/web": "^0.0.188",

--- a/templates/renderer-wasm-esm/package.json
+++ b/templates/renderer-wasm-esm/package.json
@@ -7,8 +7,8 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@types/web": "^0.0.188",

--- a/templates/tsx/package.json
+++ b/templates/tsx/package.json
@@ -8,8 +8,8 @@
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.5.5-rc7",
-    "@myriaddreamin/typst.ts": "^0.5.5-rc7"
+    "@myriaddreamin/typst-ts-renderer": "^0.6.0-rc1",
+    "@myriaddreamin/typst.ts": "^0.6.0-rc1"
   },
   "devDependencies": {
     "@types/web": "^0.0.188",


### PR DESCRIPTION
The v0.5.5 was not released because typst v0.13.0 comes before the v0.5.5 release, so we decided to skip it. The next release will be v0.6.0.