### PR TITLE
fix: property 'local-fonts' is missed in Firefox

### DIFF
--- a/packages/typst.react/src/lib/TypstDocument.tsx
+++ b/packages/typst.react/src/lib/TypstDocument.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { withGlobalRenderer } from '@myriaddreamin/typst.ts/dist/esm/contrib/global-renderer.mjs';
 import * as typst from '@myriaddreamin/typst.ts';
 import htmlLayerCss from './typst.css?inline';
@@ -21,33 +21,6 @@ let moduleInitOptions: typst.InitOptions = {
 };
 
 export const TypstDocument = ({ fill, artifact, format }: TypstDocumentProps) => {
-  /// --- beg: manipulate permission --- ///
-
-  // todo: acquire permission
-  const [permission, setPermissionInternal] = useState(false);
-  const setPermissionAndOk = (status: PermissionStatus) => {
-    if (status.state === 'granted') {
-      setPermissionInternal(true);
-      return true;
-    }
-    setPermissionInternal(false);
-    return false;
-  };
-  useEffect(() => {
-    navigator.permissions.query({ name: 'local-fonts' as PermissionName }).then(status => {
-      if (setPermissionAndOk(status)) {
-        return false;
-      }
-      status.addEventListener('change', event => {
-        console.log(event, status);
-        setPermissionAndOk(status);
-      });
-    }).catch(e => false);
-  });
-
-  /// --- end: manipulate permission --- ///
-
-  /// --- beg: update document --- ///
   const displayDivRef = useRef<HTMLDivElement>(null);
   const getDisplayLayerDiv = () => {
     return displayDivRef?.current;
@@ -83,9 +56,7 @@ export const TypstDocument = ({ fill, artifact, format }: TypstDocumentProps) =>
 
     /// render after init
     withGlobalRenderer(typst.createTypstRenderer, moduleInitOptions, doRender);
-  }, [permission, displayDivRef, fill, artifact, format]);
-
-  /// --- end: update document --- ///
+  }, [displayDivRef, fill, artifact, format]);
 
   return (
     <div>

--- a/packages/typst.react/src/lib/TypstDocument.tsx
+++ b/packages/typst.react/src/lib/TypstDocument.tsx
@@ -42,7 +42,7 @@ export const TypstDocument = ({ fill, artifact, format }: TypstDocumentProps) =>
         console.log(event, status);
         setPermissionAndOk(status);
       });
-    });
+    }).catch(e => false);
   });
 
   /// --- end: manipulate permission --- ///


### PR DESCRIPTION
typst.react crashes in firefox.

## Versions
- Browser: firefox 136.0
- OS: ubuntu 22.04

## Error Log
```
'local-fonts' (value of 'name' member of PermissionDescriptor) is not a valid value for enumeration PermissionName.
```