### PR TITLE
feat: add css format to published files in typst.react

### DIFF
--- a/packages/typst.react/package.json
+++ b/packages/typst.react/package.json
@@ -27,7 +27,7 @@
     }
   },
   "files": [
-    "dist/**/*.{mts,mjs,js,ts}"
+    "dist/**/*.{mts,mjs,js,ts,css}"
   ],
   "scripts": {
     "dev": "cd demo && vite dev -c vite.config.mjs",


### PR DESCRIPTION
Related to issue #764 

Adds built css files to the packaged files

I can't get the package to build properly, so I'm not sure if it's enough, possibly tsc or vite is not including css in the `dist` folder, so the src/lib/typst.css file would need to be copied there otherwise before publishing