### PR TITLE
fix: Prevents reinitialization of compiler and renderer options during HMR

### DIFF
--- a/packages/typst.vue3/src/Typst.vue
+++ b/packages/typst.vue3/src/Typst.vue
@@ -6,17 +6,21 @@
 import { reactive, onMounted, watch } from 'vue';
 import { $typst } from '@myriaddreamin/typst.ts';
 
-$typst.setCompilerInitOptions({
-  beforeBuild: [],
-  getModule: () =>
-    'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler_bg.wasm',
-});
+// Prevents reinitialization of compiler and renderer options during HMR (Hot Module Replacement).
+// Use prepareUseOnce flag ensures initialization occurs only once to avoid duplicate calls to setXXXInitOptions.
+if (!$typst.prepareUseOnce) {
+  $typst.setCompilerInitOptions({
+    beforeBuild: [],
+    getModule: () =>
+      'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler_bg.wasm',
+  });
 
-$typst.setRendererInitOptions({
-  beforeBuild: [],
-  getModule: () =>
-    'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm',
-});
+  $typst.setRendererInitOptions({
+    beforeBuild: [],
+    getModule: () =>
+      'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm',
+  });
+}
 
 interface prop {
   content: string;

--- a/packages/typst.vue3/src/Typst.vue
+++ b/packages/typst.vue3/src/Typst.vue
@@ -5,22 +5,7 @@
 <script setup lang="ts">
 import { reactive, onMounted, watch } from 'vue';
 import { $typst } from '@myriaddreamin/typst.ts';
-
-// Prevents reinitialization of compiler and renderer options during HMR (Hot Module Replacement).
-// Use prepareUseOnce flag ensures initialization occurs only once to avoid duplicate calls to setXXXInitOptions.
-if (!$typst.prepareUseOnce) {
-  $typst.setCompilerInitOptions({
-    beforeBuild: [],
-    getModule: () =>
-      'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler_bg.wasm',
-  });
-
-  $typst.setRendererInitOptions({
-    beforeBuild: [],
-    getModule: () =>
-      'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm',
-  });
-}
+import setTypst from './set-init-options-typst.ts';
 
 interface prop {
   content: string;
@@ -35,6 +20,7 @@ const props = withDefaults(defineProps<prop>(), {
 });
 
 onMounted(async () => {
+  setTypst();
   typst.compiled = await $typst.svg({ mainContent: props.content });
 });
 

--- a/packages/typst.vue3/src/set-init-options-typst.ts
+++ b/packages/typst.vue3/src/set-init-options-typst.ts
@@ -1,0 +1,22 @@
+// Prevents reinitialization of compiler and renderer options during HMR (Hot Module Replacement).
+// Use prepareUseOnce flag ensures initialization occurs only once to avoid duplicate calls to setXXXInitOptions.
+import { $typst } from '@myriaddreamin/typst.ts';
+
+let inited = false;
+
+export default () => {
+  if (!inited) {
+    $typst.setCompilerInitOptions({
+      beforeBuild: [],
+      getModule: () =>
+        'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler_bg.wasm',
+    });
+
+    $typst.setRendererInitOptions({
+      beforeBuild: [],
+      getModule: () =>
+        'https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm',
+    });
+    inited = true;
+  }
+};


### PR DESCRIPTION
This PR fixes issue #772 by use $typst.prepareUseOnce as flag  to ensures initialization occurs only once to avoid duplicate calls to setXXXInitOptions.