### PR TITLE
feat: generate ESM and type declarations for publishing

### DIFF
--- a/packages/typst.vue3/package.json
+++ b/packages/typst.vue3/package.json
@@ -2,10 +2,20 @@
   "name": "@myriaddreamin/typst.vue3",
   "version": "0.6.1-rc3",
   "type": "module",
-  "main": "src/Typst.vue",
+  "main": "./dist/index.umd.js",
+  "module": "./dist/index.es.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.umd.js"
+    }
+  },
   "scripts": {
     "dev": "vite -c vite.config.dev.ts",
-    "build": "vite build",
+    "build:types": "vue-tsc -p tsconfig.type.json",
+    "build": "vite build && yarn build:types",
     "publish:dry": "npm publish --dry-run --access public",
     "publish:lib": "npm publish --access public || exit 0"
   },

--- a/packages/typst.vue3/tsconfig.type.json
+++ b/packages/typst.vue3/tsconfig.type.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "dist/types",
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/packages/typst.vue3/vite.config.ts
+++ b/packages/typst.vue3/vite.config.ts
@@ -26,7 +26,8 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'Typst',
-      fileName: 'index',
+      fileName: (format) => `index.${format}.js`,
+      formats: ['es', 'umd'],
     },
     rollupOptions,
   },


### PR DESCRIPTION
This PR implements the feature requested in #775

- Update Vite config to output ESM and UMD bundles.
- Add vue-tsc declaration generation to produce .d.ts files.
- Update package.json exports and scripts for proper publishing.

No runtime code changes.
