### PR TITLE
feat: support compile with root argument

### DIFF
--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -393,6 +393,7 @@ pub struct TypstCompileWorld {
     graph: Arc<WorldComputeGraph<BrowserCompilerFeat>>,
 }
 
+#[wasm_bindgen]
 impl TypstCompileWorld {
     pub fn get_artifact(
         &mut self,

--- a/packages/typst.ts/src/compiler.mts
+++ b/packages/typst.ts/src/compiler.mts
@@ -58,6 +58,10 @@ export type DiagnosticsData = {
 
 interface CompileOptionsCommon {
   /**
+   * The root of the main file.
+   */
+  root?: string;
+  /**
    * The path of the main file.
    */
   mainFilePath: string;
@@ -443,11 +447,10 @@ class TypstCompilerDriver implements TypstCompiler {
 
   compile(options: CompileOptions): Promise<any> {
     return new Promise(resolve => {
+      const world = this.compiler.snapshot(options.root, options.mainFilePath, convertInputs(options.inputs));
       if ('incrementalServer' in options) {
         resolve(
-          this.compiler.incr_compile(
-            options.mainFilePath,
-            convertInputs(options.inputs),
+          world.incr_compile(
             options.incrementalServer[kObject],
             getDiagnosticsArg(options.diagnostics),
           ),
@@ -455,9 +458,7 @@ class TypstCompilerDriver implements TypstCompiler {
         return;
       }
       resolve(
-        this.compiler.compile(
-          options.mainFilePath,
-          convertInputs(options.inputs),
+        world.get_artifact(
           options.format || 'vector',
           getDiagnosticsArg(options.diagnostics),
         ),
@@ -467,11 +468,10 @@ class TypstCompilerDriver implements TypstCompiler {
 
   query(options: QueryOptions): Promise<any> {
     return new Promise<any>(resolve => {
+      const world = this.compiler.snapshot(options.root, options.mainFilePath, convertInputs(options.inputs));
       resolve(
         JSON.parse(
-          this.compiler.query(
-            options.mainFilePath,
-            convertInputs(options.inputs),
+          world.query(
             options.selector,
             options.field,
           ),

--- a/packages/typst.ts/src/contrib/snippet.mts
+++ b/packages/typst.ts/src/contrib/snippet.mts
@@ -29,6 +29,10 @@ type PromiseJust<T> = (() => Promise<T>) | T;
 
 interface CompileOptionsCommon {
   /**
+   * The root of the main file.
+   */
+  root?: string;
+  /**
    * Adds a string key-value pair visible through `sys.inputs`
    *
    * Note: pass `{}` to clear `sys.inputs`
@@ -45,17 +49,17 @@ interface CompileOptionsCommon {
  */
 export type SweetCompileOptions = (
   | {
-      /**
-       * The path of the main file.
-       */
-      mainFilePath: string;
-    }
+    /**
+     * The path of the main file.
+     */
+    mainFilePath: string;
+  }
   | {
-      /**
-       * The source content of the main file.
-       */
-      mainContent: string;
-    }
+    /**
+     * The source content of the main file.
+     */
+    mainContent: string;
+  }
 ) &
   CompileOptionsCommon;
 
@@ -65,11 +69,11 @@ export type SweetCompileOptions = (
 export type SweetRenderOptions =
   | SweetCompileOptions
   | {
-      /**
-       * The artifact data in vector format.
-       */
-      vectorData: Uint8Array;
-    };
+    /**
+     * The artifact data in vector format.
+     */
+    vectorData: Uint8Array;
+  };
 
 type Role = 'compiler' | 'renderer';
 


### PR DESCRIPTION
This is useful if a filesystem in browsers stores multiple typst projects.