### PR TITLE
feat: add PDF standards support for web compiler

### DIFF
--- a/packages/compiler/Cargo.toml
+++ b/packages/compiler/Cargo.toml
@@ -19,6 +19,7 @@ ansi-to-html.workspace = true
 comemo.workspace = true
 base64.workspace = true
 
+serde = { version = "1.0.210", features = ["derive"] }
 serde-wasm-bindgen.workspace = true
 serde_json.workspace = true
 

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -523,6 +523,12 @@ impl TypstCompileWorld {
         })
     }
 
+    #[cfg(feature = "pdf")]
+    pub fn set_pdf_opts(&mut self, opts: JsValue) -> Result<(), JsValue> {
+        self.pdf_opts = Some(serde_wasm_bindgen::from_value(opts).map_err(|e| format!("{e:?}"))?);
+        Ok(())
+    }
+
     fn get_diag<D: TypstDocumentTrait + Send + Sync + 'static>(
         &self,
         diagnostics_format: u8,


### PR DESCRIPTION
Using the [RenderPdfOpts](https://github.com/Myriad-Dreamin/typst.ts/blob/1afb3eebe0f884c5b93e19decfce01d7503a831a/packages/typst.node/src/lib.rs#L187) it is now possible to set the PDF options for the web compiler to specify the PDF export standard and other options using `builder.set_pdf_opts`

It can be used in the following manner and only actived when built with PDF feature:

   ```javascript
    const builder = new TypstCompilerBuilder();
    await builder.set_dummy_access_model();

    builder.set_pdf_opts({
        pdf_standard: '"2.0"', // '"1.4"' '"1.5"' '"a-1b"' '"ua-1"' etc.
        pdf_tags: null,
        creation_timestamp: null
    });

    compiler = await builder.build();
   ```