### PR TITLE
fix: Set PageMerge to default to get merged content for plain SVGs

### DIFF
--- a/packages/typst.node/src/compiler/node.rs
+++ b/packages/typst.node/src/compiler/node.rs
@@ -315,12 +315,14 @@ impl NodeCompiler {
         use reflexo_typst::task::{ExportSvgTask, PageMerge};
 
         type Export = reflexo_typst::SvgExport;
-        let output = self
-            .compile_as::<Export, ImageOutput<String>>(compiled_or_by, &ExportSvgTask {
+        let output = self.compile_as::<Export, ImageOutput<String>>(
+            compiled_or_by,
+            &ExportSvgTask {
                 // Enable merging by default for plain_svg
                 merge: Some(PageMerge::default()),
                 ..ExportSvgTask::default()
-            })?;
+            },
+        )?;
         match output {
             ImageOutput::Merged(s) => Ok(s),
             ImageOutput::Paged(..) => unreachable!(),

--- a/packages/typst.node/src/compiler/project.rs
+++ b/packages/typst.node/src/compiler/project.rs
@@ -688,15 +688,20 @@ impl NodeTypstProject {
     #[napi(ts_args_type = "compiledOrBy: NodeTypstDocument | CompileDocArgs")]
     #[cfg(feature = "svg")]
     pub fn plain_svg(&mut self, compiled_or_by: MayCompileOpts) -> Result<String, NodeError> {
-        use reflexo_typst::{task::{ExportSvgTask, PageMerge}, ImageOutput};
+        use reflexo_typst::{
+            task::{ExportSvgTask, PageMerge},
+            ImageOutput,
+        };
 
         type Export = reflexo_typst::SvgExport;
-        let output = self
-            .compile_as::<Export, ImageOutput<String>>(compiled_or_by, &ExportSvgTask {
+        let output = self.compile_as::<Export, ImageOutput<String>>(
+            compiled_or_by,
+            &ExportSvgTask {
                 // Enable merging by default for plain_svg
                 merge: Some(PageMerge::default()),
                 ..ExportSvgTask::default()
-            })?;
+            },
+        )?;
         match output {
             ImageOutput::Merged(s) => Ok(s),
             ImageOutput::Paged(..) => unreachable!(),


### PR DESCRIPTION
Fixes #824

Explanation: The plain SVG target expected merged pages, while this is only true when the `merge` option is set in `ExportSvgTask`, so the simplest fix to this is to add a default `PageMerge` to the options.

This can be verified by adding the following test to `simple-test.js`:
```js
console.assert(
  !!cc.plainSvg({
    mainFileContent: `
    #set page(width: auto, height: auto, margin: 0pt)

    Hello, Typst!
    `,
  }),
  'Simple test failed',
);
```
which, now with the fix, will pass.

P.S., it might be a good idea to expose this option to the node API, but that's a different topic and requires consideration. The current fix just get the failing compilation to work.