### PR TITLE
fix: update peer dependency of vite-plugin-typst for vite to support version 7

### DIFF
--- a/projects/vite-plugin-typst/package.json
+++ b/projects/vite-plugin-typst/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@myriaddreamin/typst.node": "^0.7.0-rc2",
     "@xmldom/xmldom": "^0.9.8",
-    "vite": "^6.2.3"
+    "vite": "^6.2.3 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "@myriaddreamin/typst.node": {


### PR DESCRIPTION
I'm using vite 7 and I wants to install vite-plugin-typst, so I requst to add vite@7 to peer dependency of vite-plugin-typst