### PR TITLE
fix(vite-plugin): always resolve typst imports to absolute paths

### DIFF
--- a/projects/vite-plugin-typst/src/index.ts
+++ b/projects/vite-plugin-typst/src/index.ts
@@ -230,14 +230,18 @@ export default parts;`;
       return `export default ${JSON.stringify(result.result!.html())}`;
     },
 
-    resolveId(source) {
-      const { path, attributes } = extractOpts(source);
-      if (!path.endsWith('.typ')) return null;
+    resolveId(source, importer) {
+      const { path: filepath, attributes } = extractOpts(source);
+      if (!filepath.endsWith(".typ")) return null;
+      const abspath = path.isAbsolute(filepath)
+        ? filepath
+        : path.resolve(path.dirname(importer), source);
       if (attributes.html || attributes.parts) {
-        return source + suffixJs;
+        return abspath + suffixJs;
       }
-      return provider.resolveRel(path);
+      return provider.resolveRel(abspath);
     },
+
 
     config(conf) {
       viteReload(conf as unknown as ResolvedConfig);

--- a/projects/vite-plugin-typst/src/index.ts
+++ b/projects/vite-plugin-typst/src/index.ts
@@ -242,7 +242,6 @@ export default parts;`;
       return provider.resolveRel(abspath);
     },
 
-
     config(conf) {
       viteReload(conf as unknown as ResolvedConfig);
       inputs.mutate(options, conf as unknown as ResolvedConfig)!;


### PR DESCRIPTION
I don't know if this is the correct fix but it does work for me, i just came up with the fix after debugging for a while and looked at various vite plugins to see if they do similar things.

**Motivation:** I'm setting up a SvelteKit blog and I want to write articles in typst then compile to HTML.

## Expected:

When i have this [/blog/article/[[slug]]/page.server.ts](https://github.com/pynappo/pynappo.dev/blob/main/src/routes/blog/article/%5B%5Bslug%5D%5D/%2Bpage.server.ts), navigating to `/blog/article/init` should be able to properly import [blog/article/init.typ](https://github.com/pynappo/pynappo.dev/blob/main/src/routes/blog/article/init.typ).

## Actual:

Somehow, this works with vite dev but not vite build. It looks like when I use a relative path to a typst file, the vite plugin does not resolve the relative id, so the compiler assumes the path is relative to the root of the project at build time.

In dev, it seems like vite automatically resolves the id to an absolute path before the vite plugin gets it.

I originally figured out this behavior by switching the vite plugin to use `typst-cli` and then printing out the command that vite-plugin-typst uses. I don't have the exact logs atm but it was basically:

With vite dev:

```
typst compile --root /root/of/project/typst /root/of/project/typst/src/routes/blog/article/init.typ
```

With vite build:

```
typst compile --root /root/of/project/typst ../init.typ
```