### PR TITLE
fix(rustdoc-typst-demo): render equations in item overview

### DIFF
--- a/projects/rustdoc-typst-demo/typst-header.html
+++ b/projects/rustdoc-typst-demo/typst-header.html
@@ -71,7 +71,7 @@
         p.parentNode.insertBefore(createElem(svg, true), p.nextSibling);
       });
     });
-    document.querySelectorAll('p code').forEach(p => {
+    document.querySelectorAll('p code, dd code').forEach(p => {
       if (!(p.textContent.startsWith('{') && p.textContent.endsWith('}'))) {
         return;
       }


### PR DESCRIPTION
Module item descriptions render the first line of docs in a `dd`, not a `p`. Adds `dd code` to the query selector.

Before:
<img width="719" height="218" alt="Screenshot 2026-04-10 170607" src="https://github.com/user-attachments/assets/49737862-5833-4549-8dbe-51f0c31afbc9" />


After:
<img width="574" height="221" alt="image" src="https://github.com/user-attachments/assets/80f415b7-6eac-4809-91e1-3a67120b7d07" />
