### PR TITLE
fix: publish npm packages to npm registry

### DIFF
--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -10,6 +10,8 @@ env:
   DEBUG: napi:*
   APP_NAME: typst-ts-node-compiler
   MACOSX_DEPLOYMENT_TARGET: '10.13'
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+  YARN_REGISTRY: https://registry.npmjs.org/
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+  YARN_REGISTRY: https://registry.npmjs.org/
+
 concurrency:
   group: release-orchestrate-${{ github.ref }}-${{ inputs.tag }}
   cancel-in-progress: false

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -7,6 +7,7 @@ This repository now uses a manual, auditable release layout centered on one top-
 - GitHub Environment: `npm-publish`
 - Trusted publishing runtime: Node `22.14.0` or newer with npm `11.5.1` or newer
 - npm credentials: GitHub OIDC with `id-token: write`
+- npm registry: release workflows set npm and Yarn registry environment to `https://registry.npmjs.org/`
 - npm token handling: the generic package, `typst.node`, and project publish jobs do not use `NPM_TOKEN` or write a registry token into `.npmrc`
 
 ## Workflow coverage

--- a/openspec/specs/npm-trusted-publishing/spec.md
+++ b/openspec/specs/npm-trusted-publishing/spec.md
@@ -9,6 +9,7 @@ Any npm publish workflow created or migrated by this change SHALL use GitHub Act
 #### Scenario: Live publish job authenticates to npm
 - **WHEN** a covered live publish workflow starts its npm publish step
 - **THEN** the workflow requests `id-token: write`
+- **AND** the workflow configures npm and Yarn registry environment for `https://registry.npmjs.org/`
 - **AND** the workflow does not require `NPM_TOKEN`
 - **AND** the workflow does not write a registry authentication token into `.npmrc`
 
@@ -31,4 +32,3 @@ The repository SHALL gate live npm publish jobs behind a top-level `workflow_dis
 #### Scenario: Publish job waits for approval
 - **WHEN** a maintainer dispatches a live npm publish workflow
 - **THEN** GitHub requires the configured environment approval before the workflow runs npm publish steps
-


### PR DESCRIPTION
## Summary
- set `YARN_REGISTRY` and `NPM_CONFIG_REGISTRY` in the release orchestration workflow so Yarn-run npm publishes use npmjs instead of yarnpkg
- set the same registry environment in the reusable typst.node release workflow because reusable workflows do not inherit caller workflow env
- document the CI-level registry override in release docs and OpenSpec

## Verification
- `YARN_REGISTRY=https://registry.npmjs.org/ yarn --cwd projects/rehype-typst exec npm config get registry` returned `https://registry.npmjs.org/`
- `NPM_CONFIG_CACHE=/tmp/npm-cache YARN_REGISTRY=https://registry.npmjs.org/ yarn --cwd projects/rehype-typst publish:lib --dry-run --loglevel=notice` ended with `Publishing to https://registry.npmjs.org/ ... (dry-run)`
- `git diff --check`
- `openspec validate --specs --strict`