### PR TITLE
fix: add repository metadata for npm provenance

### DIFF
--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -9,6 +9,7 @@ This repository now uses a manual, auditable release layout centered on one top-
 - npm credentials: GitHub OIDC with `id-token: write`
 - npm registry: release workflows set npm and Yarn registry environment to `https://registry.npmjs.org/`
 - npm token handling: the generic package, `typst.node`, and project publish jobs do not use `NPM_TOKEN` or write a registry token into `.npmrc`
+- npm provenance metadata: published package manifests set `repository.url` to `https://github.com/Myriad-Dreamin/typst.ts`
 
 ## Workflow coverage
 

--- a/openspec/specs/npm-trusted-publishing/spec.md
+++ b/openspec/specs/npm-trusted-publishing/spec.md
@@ -10,6 +10,7 @@ Any npm publish workflow created or migrated by this change SHALL use GitHub Act
 - **WHEN** a covered live publish workflow starts its npm publish step
 - **THEN** the workflow requests `id-token: write`
 - **AND** the workflow configures npm and Yarn registry environment for `https://registry.npmjs.org/`
+- **AND** the package manifest declares `repository.url` matching the GitHub repository used by provenance
 - **AND** the workflow does not require `NPM_TOKEN`
 - **AND** the workflow does not write a registry authentication token into `.npmrc`
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -4,6 +4,10 @@
   "description": "WASM module for Compiling Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "TypeScript",
     "Typst"

--- a/packages/ng/compiler/package.json
+++ b/packages/ng/compiler/package.json
@@ -4,6 +4,10 @@
   "description": "Compile Typst documents in Browsers.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "TypeScript",
     "Typst"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -4,6 +4,10 @@
   "description": "WASM module for Parsing Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "TypeScript",
     "Typst"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -4,6 +4,10 @@
   "description": "WASM module for rendering Typst documents in browser.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "TypeScript",
     "Typst"

--- a/packages/typst-all-in-one.ts/package.json
+++ b/packages/typst-all-in-one.ts/package.json
@@ -4,6 +4,10 @@
     "description": "Run Typst in JavaScriptWorld with a single bundled library.",
     "author": "Myriad-Dreamin",
     "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Myriad-Dreamin/typst.ts"
+    },
     "keywords": [
         "TypeScript",
         "Typst"

--- a/packages/typst.angular/projects/typst.angular/package.json
+++ b/packages/typst.angular/projects/typst.angular/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.0",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "Angular",
     "TypeScript",

--- a/packages/typst.node/npm/android-arm-eabi/package.json
+++ b/packages/typst.node/npm/android-arm-eabi/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "arm"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.android-arm-eabi.node",
   "files": [
     "typst-ts-node-compiler.android-arm-eabi.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/android-arm64/package.json
+++ b/packages/typst.node/npm/android-arm64/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "arm64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.android-arm64.node",
   "files": [
     "typst-ts-node-compiler.android-arm64.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/darwin-arm64/package.json
+++ b/packages/typst.node/npm/darwin-arm64/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "arm64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.darwin-arm64.node",
   "files": [
     "typst-ts-node-compiler.darwin-arm64.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/darwin-x64/package.json
+++ b/packages/typst.node/npm/darwin-x64/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "x64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.darwin-x64.node",
   "files": [
     "typst-ts-node-compiler.darwin-x64.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/freebsd-x64/package.json
+++ b/packages/typst.node/npm/freebsd-x64/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "x64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.freebsd-x64.node",
   "files": [
     "typst-ts-node-compiler.freebsd-x64.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/linux-arm-gnueabihf/package.json
+++ b/packages/typst.node/npm/linux-arm-gnueabihf/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "arm"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.linux-arm-gnueabihf.node",
   "files": [
     "typst-ts-node-compiler.linux-arm-gnueabihf.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/linux-arm64-gnu/package.json
+++ b/packages/typst.node/npm/linux-arm64-gnu/package.json
@@ -10,7 +10,6 @@
   "libc": [
     "glibc"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.linux-arm64-gnu.node",
   "files": [
     "typst-ts-node-compiler.linux-arm64-gnu.node"
@@ -25,6 +24,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/linux-arm64-musl/package.json
+++ b/packages/typst.node/npm/linux-arm64-musl/package.json
@@ -10,7 +10,6 @@
   "libc": [
     "musl"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.linux-arm64-musl.node",
   "files": [
     "typst-ts-node-compiler.linux-arm64-musl.node"
@@ -25,6 +24,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/linux-x64-gnu/package.json
+++ b/packages/typst.node/npm/linux-x64-gnu/package.json
@@ -10,7 +10,6 @@
   "libc": [
     "glibc"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.linux-x64-gnu.node",
   "files": [
     "typst-ts-node-compiler.linux-x64-gnu.node"
@@ -25,6 +24,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/linux-x64-musl/package.json
+++ b/packages/typst.node/npm/linux-x64-musl/package.json
@@ -10,7 +10,6 @@
   "libc": [
     "musl"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.linux-x64-musl.node",
   "files": [
     "typst-ts-node-compiler.linux-x64-musl.node"
@@ -25,6 +24,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/win32-arm64-msvc/package.json
+++ b/packages/typst.node/npm/win32-arm64-msvc/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "arm64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.win32-arm64-msvc.node",
   "files": [
     "typst-ts-node-compiler.win32-arm64-msvc.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/npm/win32-x64-msvc/package.json
+++ b/packages/typst.node/npm/win32-x64-msvc/package.json
@@ -7,7 +7,6 @@
   "cpu": [
     "x64"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "typst-ts-node-compiler.win32-x64-msvc.node",
   "files": [
     "typst-ts-node-compiler.win32-x64-msvc.node"
@@ -22,6 +21,10 @@
     "node-addon-api"
   ],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "engines": {
     "node": ">= 10"
   },

--- a/packages/typst.node/package.json
+++ b/packages/typst.node/package.json
@@ -5,7 +5,10 @@
   "description": "Compile or Render Typst documents in Node environment.",
   "main": "index.js",
   "license": "Apache-2.0",
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "typst",
     "compiler",

--- a/packages/typst.react/package.json
+++ b/packages/typst.react/package.json
@@ -4,6 +4,10 @@
   "description": "Typst.ts for React",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "React",
     "TypeScript",
@@ -13,7 +17,6 @@
     "url": "https://github.com/Myriad-Dreamin/typst.ts/issues"
   },
   "homepage": "https://myriad-dreamin.github.io/typst.ts/",
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/typst.solid/package.json
+++ b/packages/typst.solid/package.json
@@ -31,5 +31,9 @@
     "typst",
     "typescript",
     "vite"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  }
 }

--- a/packages/typst.svelte/package.json
+++ b/packages/typst.svelte/package.json
@@ -52,5 +52,9 @@
 	},
 	"keywords": [
 		"svelte"
-	]
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Myriad-Dreamin/typst.ts"
+	}
 }

--- a/packages/typst.ts/package.json
+++ b/packages/typst.ts/package.json
@@ -4,6 +4,10 @@
   "description": "Run Typst in JavaScriptWorld.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "TypeScript",
     "Typst"

--- a/packages/typst.vue3/package.json
+++ b/packages/typst.vue3/package.json
@@ -32,5 +32,9 @@
     "vue": "^3.5.13",
     "vue-tsc": "^2.2.2"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  }
 }

--- a/projects/hexo-renderer-typst/package.json
+++ b/projects/hexo-renderer-typst/package.json
@@ -4,12 +4,15 @@
   "description": "Typst renderer plugin for Hexo",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "hexo",
     "typst",
     "renderer"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "index.cjs",
   "files": [
     "index.cjs",

--- a/projects/highlighter/package.json
+++ b/projects/highlighter/package.json
@@ -4,11 +4,14 @@
   "description": "typst code highlighting support in web",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "keywords": [
     "highlighting",
     "typst"
   ],
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/esm/index.d.mts",

--- a/projects/rehype-typst/package.json
+++ b/projects/rehype-typst/package.json
@@ -4,6 +4,10 @@
   "description": "rehype plugin for rendering typst math equations",
   "main": "index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "sideEffects": false,
   "type": "module",
   "exports": "./index.js",

--- a/projects/vite-plugin-typst/package.json
+++ b/projects/vite-plugin-typst/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Myriad-Dreamin/typst.ts"
+  },
   "type": "module",
   "scripts": {
     "build": "npx tsc",
@@ -13,7 +17,6 @@
     "publish:dry": "npm publish --dry-run",
     "publish:lib": "npm publish --access public || exit 0"
   },
-  "repository": "https://github.com/Myriad-Dreamin/typst.ts",
   "keywords": [
     "vite",
     "vite-plugin",


### PR DESCRIPTION
## Summary
- add package manifest `repository.url` metadata required by npm provenance verification
- cover generic workspace npm packages, project npm packages, the Angular publish manifest, typst.node root, and typst.node platform manifests
- document the provenance metadata requirement in release docs and OpenSpec

## Verification
- repository metadata check for 28 release package manifests
- publishable npm script manifest scan confirmed non-private npm publish packages declare `repository.url`
- JSON parse check for 28 changed package manifests
- `NPM_CONFIG_CACHE=/tmp/npm-cache yarn --cwd projects/rehype-typst publish:dry --json`
- `git diff --check`
- `openspec validate --specs --strict`