### PR TITLE
test: skip flaky page label canvas snapshot

### DIFF
--- a/packages/typst.ts/tests/meta/page-label_00.browser.test.mts
+++ b/packages/typst.ts/tests/meta/page-label_00.browser.test.mts
@@ -12,7 +12,8 @@ describe('renderer', () => {
     await makeSnapshot(await testSvg(await getFile()), `${fileName}.svg.png`);
   });
 
-  it('should renderer canvas', async () => {
+  // This canvas snapshot alternates between two hashes on CI.
+  it.skip('should renderer canvas', async () => {
     await makeSnapshot(await testCanvas(await getFile()), `${fileName}.canvas.png`);
   });
 });


### PR DESCRIPTION
## Summary
- skip the unstable page-label canvas browser snapshot case
- keep the SVG snapshot test active

## Context
The canvas hash for tests/meta/page-label_00.browser.test.mts alternates in CI between:
- ihash16:a017a017e417f51fa017b51fa51fa00fb19fa01f800fe11fa017a017b51fa51f?size=120x1702.400146484375
- ihash16:a017a017e417f51fa017b51fa51fa00fa19fa01f800fe19fa017a017b51fa51f?size=120x1702.400146484375

Updating the snapshot just flips the failure on the next run, so this PR disables only that flaky canvas case.

## Validation
- git diff --check
- attempted yarn --cwd packages/typst.ts test tests/meta/page-label_00.browser.test.mts, but the local workspace is missing @vitest/browser-playwright, so Vitest could not load the browser config