### PR TITLE
fix: fix tinymist entry selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1192,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1969,7 +1969,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2776,7 +2776,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3269,7 +3269,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -3306,9 +3306,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3955,7 +3955,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4594,7 +4594,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4613,7 +4613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4736,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "tinymist-derive"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4745,7 +4745,7 @@ dependencies = [
 [[package]]
 name = "tinymist-l10n"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "anyhow",
  "clap",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "tinymist-package"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "tinymist-project"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "anyhow",
  "clap",
@@ -4814,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "tinymist-std"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "tinymist-task"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "anyhow",
  "clap",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "tinymist-vfs"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "comemo",
  "ecow",
@@ -4907,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "tinymist-world"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5513,7 +5513,7 @@ dependencies = [
 [[package]]
 name = "typst-shim"
 version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=22b13f64af7931ca9179e6ea0e1e4316cb88f92b#22b13f64af7931ca9179e6ea0e1e4316cb88f92b"
+source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=4951a39a80e808bd411807e46da645e12c52c923#4951a39a80e808bd411807e46da645e12c52c923"
 dependencies = [
  "cfg-if",
  "comemo",
@@ -6454,7 +6454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,13 +277,13 @@ typst-bundle = { git = "https://github.com/Myriad-Dreamin/typst.git", rev = "f05
 
 # fontdb = { path = "../fontdb" }
 
-typst-shim = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-derive = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-std = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-task = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-package = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-world = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
-tinymist-project = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "22b13f64af7931ca9179e6ea0e1e4316cb88f92b" }
+typst-shim = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-derive = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-std = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-task = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-package = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-world = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
+tinymist-project = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "4951a39a80e808bd411807e46da645e12c52c923" }
 
 # typst-shim = { path = "../tinymist/crates/typst-shim" }
 # tinymist-derive = { path = "../tinymist/crates/tinymist-derive" }

--- a/crates/reflexo-typst/src/error.rs
+++ b/crates/reflexo-typst/src/error.rs
@@ -139,11 +139,7 @@ fn resolve_source_span(
                 path = id.vpath().get_with_slash().to_string();
             }
             Ok(WorkspaceResolution::Workspace(workspace)) => {
-                path = id
-                    .vpath()
-                    .realize(&workspace.path())
-                    .map(|path| unix_slash(&path))
-                    .unwrap_or_else(|_| id.vpath().get_with_slash().to_string());
+                path = unix_slash(&id.vpath().realize(&workspace.path()));
             }
             Err(..) => {}
         }

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -8,11 +8,7 @@ pub use crate::builder::TypstFontResolver;
 pub use reflexo_typst::*;
 
 use core::fmt;
-use std::{
-    fmt::Write,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{fmt::Write, path::Path, sync::Arc};
 
 use error::TypstSourceDiagnostic;
 use font::cache::FontInfoCache;
@@ -39,34 +35,6 @@ use incr::IncrServer;
 /// main.typ:2:9-3:15: error: unexpected type in `+` application
 /// ```
 struct UnixFmt(DiagMessage);
-
-fn select_entry_in_workspace(
-    entry: reflexo_typst::EntryState,
-    main_file_path: &str,
-) -> Result<reflexo_typst::EntryState, JsValue> {
-    let path = Path::new(main_file_path);
-    let Some(root) = entry.root() else {
-        return Ok(entry.select_in_workspace(path));
-    };
-
-    let path = path.strip_prefix(&root).map_err(|err| {
-        error_once!(
-            "entry file is not in workspace",
-            err: err,
-            entry: path.display(),
-            root: root.display()
-        )
-    })?;
-    let path = root_relative_to_virtual(path)?;
-    Ok(entry.select_in_workspace(&path))
-}
-
-fn root_relative_to_virtual(path: &Path) -> Result<PathBuf, JsValue> {
-    let path = path
-        .to_str()
-        .ok_or_else(|| error_once!("entry file path must be utf-8", path: path.display()))?;
-    Ok(PathBuf::from(format!("/{}", path.trim_start_matches('/'))))
-}
 
 impl fmt::Display for UnixFmt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -336,7 +304,9 @@ impl TypstCompiler {
         };
 
         let entry = if let Some(main_file_path) = main_file_path {
-            select_entry_in_workspace(entry, &main_file_path)?
+            entry
+                .try_select_path_in_workspace(Path::new(&main_file_path))?
+                .ok_or_else(|| error_once!("failed to select path", path: main_file_path))?
         } else {
             entry.clone()
         };

--- a/packages/ng/compiler/src/lib.rs
+++ b/packages/ng/compiler/src/lib.rs
@@ -1,11 +1,6 @@
-use std::{
-    ops::Deref,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{ops::Deref, path::Path, sync::Arc};
 
 use js_sys::{Object, Uint8Array};
-use reflexo_typst::EntryState;
 use reflexo_typst::{
     font::web::BrowserFontSearcher,
     foundations::IntoValue,
@@ -45,13 +40,6 @@ impl Snapshot {
             errors: Vec::new(),
         })
     }
-}
-
-fn root_relative_to_virtual(path: &Path) -> Result<PathBuf, JsValue> {
-    let path = path
-        .to_str()
-        .ok_or_else(|| format!("entry file path must be utf-8: {}", path.display()))?;
-    Ok(PathBuf::from(format!("/{}", path.trim_start_matches('/'))))
 }
 
 #[wasm_bindgen]
@@ -191,7 +179,9 @@ impl TypstCompiler {
             None => Ok(None),
             Some(args) => Ok(Some(TaskInputs {
                 entry: match args.main_file_path {
-                    Some(path) => Self::select_entry_in_workspace(ctx.entry_state(), &path)?,
+                    Some(path) => ctx
+                        .entry_state()
+                        .try_select_path_in_workspace(Path::new(&path))?,
                     None => None,
                 },
                 inputs: args
@@ -199,26 +189,6 @@ impl TypstCompiler {
                     .map(|inputs| Arc::new(LazyHash::new(convert_inputs(&inputs)))),
             })),
         }
-    }
-
-    fn select_entry_in_workspace(
-        entry: EntryState,
-        main_file_path: &str,
-    ) -> Result<Option<EntryState>, JsValue> {
-        let path = Path::new(main_file_path);
-        let Some(root) = entry.root() else {
-            return Ok(Some(entry.select_in_workspace(path)));
-        };
-
-        let path = path.strip_prefix(&root).map_err(|err| {
-            format!(
-                "entry file is not in workspace: {err}; entry: {}; root: {}",
-                path.display(),
-                root.display()
-            )
-        })?;
-        let path = root_relative_to_virtual(path)?;
-        Ok(Some(entry.select_in_workspace(&path)))
     }
 
     fn compile_doc(&mut self, input: &SnapshotArgs) -> Result<TypstDocument, JsValue> {

--- a/server/dev/src/main.rs
+++ b/server/dev/src/main.rs
@@ -6,8 +6,7 @@ use std::process::exit;
 use clap::Parser;
 use log::info;
 use reflexo_typst::path::PathClean;
-use reflexo_typst::typst::syntax::VirtualPath;
-use reflexo_typst::{DiagnosticsTask, EntryReader, EntryState, TaskInputs};
+use reflexo_typst::{DiagnosticsTask, EntryReader, TaskInputs};
 use tokio::io::AsyncBufReadExt;
 use typst_ts_cli::export::ReflexoTaskBuilder;
 use typst_ts_dev_server::{
@@ -88,9 +87,20 @@ fn compile_corpus(args: CompileCorpusArgs) {
         tb.args(&compile_args, Some(&entry));
         let exporter = tb.build();
 
-        let entry = match select_entry_in_workspace(&verse.entry_state(), &entry) {
-            Ok(entry) => entry,
-            Err(err) => return Some(format!("{cat}/{name}: {err}")),
+        let entry = match verse.entry_state().try_select_path_in_workspace(&entry) {
+            Ok(Some(entry)) => entry,
+            Ok(None) => {
+                return Some(format!(
+                    "{cat}/{name}: failed to select entry file {}",
+                    entry.display()
+                ));
+            }
+            Err(err) => {
+                return Some(format!(
+                    "{cat}/{name}: failed to select entry file {}: {err}",
+                    entry.display()
+                ));
+            }
         };
         let graph = verse.computation_with(TaskInputs {
             entry: Some(entry),
@@ -203,23 +213,6 @@ fn expected_artifact_paths(entry: &Path, formats: &[String]) -> Vec<PathBuf> {
     paths.sort();
     paths.dedup();
     paths
-}
-
-fn select_entry_in_workspace(state: &EntryState, entry: &Path) -> Result<EntryState, String> {
-    match state.workspace_root() {
-        Some(root) => {
-            let main = VirtualPath::virtualize(&root, entry).map_err(|err| {
-                format!(
-                    "cannot select entry file out of workspace: {err}; entry: {}; root: {}",
-                    entry.display(),
-                    root.display()
-                )
-            })?;
-            Ok(EntryState::new_rooted(root, Some(main)))
-        }
-        None => EntryState::new_rooted_by_parent(entry.into())
-            .ok_or_else(|| format!("failed to determine root for {}", entry.display())),
-    }
 }
 
 const fn yarn_cmd() -> &'static str {


### PR DESCRIPTION

- Pin tinymist git dependencies to `4951a39a80e808bd411807e46da645e12c52c923`.
- Update `Cargo.lock` for the tinymist-family packages at that commit.
- Remove the local entry-selection workaround so the tinymist fix is used directly.
- Keep the `VirtualPath::realize` API compatibility fix in `reflexo-typst`.
