### PR TITLE
fix: lower variable font glyph outlines with skrifa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "skrifa",
  "svgtypes 0.15.3",
  "tiny-skia 0.11.4",
  "tiny-skia-path 0.11.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ typst-syntax = "0.15.0-rc.1"
 typst-html = "0.15.0-rc.1"
 
 ttf-parser = "0.25.0"
+skrifa = "0.42.1"
 
 typst-assets = { git = "https://github.com/typst/typst-assets", rev = "955ae8d" }
 typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", rev = "0b12d75772199e07294749ffe078ea030b857746" }

--- a/crates/conversion/typst2vec/Cargo.toml
+++ b/crates/conversion/typst2vec/Cargo.toml
@@ -24,6 +24,7 @@ serde.workspace = true
 serde_json.workspace = true
 tiny-skia.workspace = true
 log.workspace = true
+skrifa.workspace = true
 flate2.workspace = true
 xmlparser.workspace = true
 rayon.workspace = true

--- a/crates/conversion/typst2vec/src/font/glyph.rs
+++ b/crates/conversion/typst2vec/src/font/glyph.rs
@@ -4,6 +4,8 @@ use std::{ops::Deref, sync::Arc};
 
 use reflexo::hash::{item_hash128, HashedTrait, StaticHash128};
 use reflexo::ImmutStr;
+use skrifa::outline::{DrawSettings, OutlinePen};
+use skrifa::{FontRef as SkrifaFontRef, MetadataProvider};
 use typst::foundations::{Bytes, Smart};
 use typst::text::FontInstance;
 use typst::visualize::{ExchangeFormat, Image as TypstImage, RasterImage};
@@ -137,12 +139,27 @@ impl IGlyphProvider for FontGlyphProvider {
 
     /// See [`IGlyphProvider::outline_glyph`] for more information.
     fn outline_glyph(&self, font: &FontInstance, id: GlyphId) -> Option<String> {
-        let font_face = font.ttf();
+        let font_ref =
+            SkrifaFontRef::from_index(font.font().data().as_slice(), font.font().index()).ok()?;
+        let variations: Vec<_> = font
+            .variations()
+            .0
+            .iter()
+            .map(|(tag, value)| (skrifa::Tag::new(&tag.to_bytes()), value.0))
+            .collect();
+        let location = font_ref.axes().location(variations.iter().copied());
+        let glyph = font_ref
+            .outline_glyphs()
+            .get(skrifa::GlyphId::new(id.0.into()))?;
 
-        // todo: handling no such glyph
         let mut builder = SvgOutlineBuilder(String::new());
-        font_face.outline_glyph(id, &mut builder)?;
-        Some(builder.0)
+        glyph
+            .draw(
+                DrawSettings::unhinted(skrifa::instance::Size::unscaled(), &location),
+                &mut builder,
+            )
+            .ok()?;
+        (!builder.0.is_empty()).then_some(builder.0)
     }
 }
 
@@ -181,7 +198,7 @@ impl IGlyphProvider for DummyFontGlyphProvider {
 #[derive(Default)]
 struct SvgOutlineBuilder(pub String);
 
-impl ttf_parser::OutlineBuilder for SvgOutlineBuilder {
+impl OutlinePen for SvgOutlineBuilder {
     fn move_to(&mut self, x: f32, y: f32) {
         write!(&mut self.0, "M {x} {y} ").unwrap();
     }


### PR DESCRIPTION
## Summary
- lower outline glyphs through `skrifa` instead of `ttf-parser` so variable font outlines are drawn at the active instance location
- build the `skrifa` font ref from the `FontInstance` font data and TTC index
- pass `FontInstance` variations into the `skrifa` axis location while preserving glyph ids exactly for lookup

## Test Plan
- `cargo fmt --package reflexo-typst2vec`
- `cargo check -p reflexo-typst2vec`
- `cargo check --locked -p reflexo-typst2vec`

## Risk Notes
- Stacked on #854 / `tinymist-v0.15.0-main-pr`; retarget to `main` after that branch lands if needed.
- Outline extraction now depends on `skrifa` behavior for variable glyph drawing. SVG glyph and bitmap glyph paths still use the existing `ttf-parser` accessors.
- Empty outlines continue to return `None`, matching the fallback behavior expected by glyph lowering.
