### PR TITLE
build: bump version to v0.8.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "ansi_term",
  "codespan-reporting",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst-compiler"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "ansi-to-html",
  "base64 0.22.1",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst2hast"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-typst2vec"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "bitvec",
  "comemo",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2bbox"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "comemo",
  "reflexo",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2canvas"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "async-trait",
  "comemo",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2dom"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "async-recursion",
  "comemo",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2sema"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "comemo",
  "js-sys",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "reflexo-vec2svg"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-bench-lowering"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "comemo",
  "divan",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-cli"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-dev-server"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "bytes",
  "clap",
@@ -5635,7 +5635,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-docs-test"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-heap-profile-test"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "comemo",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-incremental-fuzzer"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "comemo",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-incremental-test"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "comemo",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-node-compiler"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "chrono",
  "comemo",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-parser"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-renderer"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -5769,14 +5769,14 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-rkyv-assertions"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "reflexo-typst2vec",
 ]
 
 [[package]]
 name = "typst-ts-std-test"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "anyhow",
  "rayon",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-test-common"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-web-compiler"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 dependencies = [
  "ansi-to-html",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1060,7 +1060,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1968,7 +1968,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2775,7 +2775,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3268,7 +3268,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -3305,9 +3305,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3959,7 +3959,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4392,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4417,7 +4417,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4598,7 +4598,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4617,7 +4617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4738,8 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-derive"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b45f4d5b1d278b445bcc2962a9972c333af5b1133ebc6eb9bfb9d719e14262"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4747,8 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-l10n"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd579cc169be8bf795652662db861e9d5770e822e5973ae30b965879886b0160"
 dependencies = [
  "anyhow",
  "clap",
@@ -4761,8 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-package"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db53402404ca6c76c4cb287653d222e3bdb9382663cccebc82dd24a0bb87aaa5"
 dependencies = [
  "base64 0.22.1",
  "comemo",
@@ -4787,8 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-project"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aead77722c6c95fbea896d9932b0c97040ba51f37c846ec550795dcfec75650"
 dependencies = [
  "anyhow",
  "clap",
@@ -4811,13 +4815,14 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "typst",
- "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=3284e80)",
+ "typst-assets",
 ]
 
 [[package]]
 name = "tinymist-std"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ade1db8629802c6ba4c4b336bd8a14f42b12daba96950054cb182721c6186ce"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4855,8 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-task"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d02f04bef3ccfcaf92cb8766bd7c3936069c8b84b952fbcc51be94f1046877c"
 dependencies = [
  "anyhow",
  "clap",
@@ -4878,7 +4884,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "typst",
- "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=3284e80)",
+ "typst-assets",
  "typst-eval",
  "typst-html",
  "typst-layout",
@@ -4890,8 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-vfs"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e02b317dc194bbfbc40eddcc685821489a90eab6f9d73aa985b27bbd33c7f14"
 dependencies = [
  "comemo",
  "ecow",
@@ -4909,8 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "tinymist-world"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6624ad090ad0cf8c2774228aa07120a23cf284483a77fe04f74eba185161d87c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4941,7 +4949,7 @@ dependencies = [
  "tinymist-vfs",
  "ttf-parser",
  "typst",
- "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=3284e80)",
+ "typst-assets",
  "typst-bundle",
  "typst-shim",
  "wasm-bindgen",
@@ -5224,22 +5232,6 @@ dependencies = [
 
 [[package]]
 name = "typst-assets"
-version = "0.14.2"
-source = "git+https://github.com/typst/typst-assets?rev=3284e80#3284e80cc102b402e4e3db1aa071f1eadae5e7ca"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "typst-assets"
-version = "0.14.2"
-source = "git+https://github.com/typst/typst-assets?rev=955ae8d#955ae8db08d6e36694eb9cc61e61f586032ea572"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "typst-assets"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9b236d339dce0ec443dc44afe4ba4c6d76b8917bd4b1ae80158d2111f6637b"
@@ -5306,7 +5298,7 @@ dependencies = [
  "palette",
  "rustc-hash 2.1.2",
  "time",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-library",
  "typst-macros",
  "typst-svg",
@@ -5357,7 +5349,7 @@ dependencies = [
  "rustybuzz",
  "smallvec",
  "ttf-parser",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-library",
  "typst-macros",
  "typst-syntax",
@@ -5420,7 +5412,7 @@ dependencies = [
  "ttf-parser",
  "two-face",
  "typed-arena",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-macros",
  "typst-syntax",
  "typst-timing",
@@ -5465,7 +5457,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "smallvec",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-layout",
  "typst-library",
  "typst-macros",
@@ -5506,7 +5498,7 @@ dependencies = [
  "resvg",
  "tiny-skia 0.12.0",
  "ttf-parser",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-layout",
  "typst-library",
  "typst-macros",
@@ -5516,8 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "typst-shim"
-version = "0.15.0-rc1"
-source = "git+https://github.com/Myriad-Dreamin/tinymist.git?rev=692fca76e4e50f7ac462ba1c49646084627f0ef8#692fca76e4e50f7ac462ba1c49646084627f0ef8"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bf8601fa988e7ae7929b2f5303d2ade335d67c5a605ad39c27d9e3aada3cda"
 dependencies = [
  "cfg-if",
  "comemo",
@@ -5543,7 +5536,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "ryu",
  "ttf-parser",
- "typst-assets 0.15.0",
+ "typst-assets",
  "typst-layout",
  "typst-library",
  "typst-macros",
@@ -5614,7 +5607,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "typst",
- "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=955ae8d)",
+ "typst-assets",
  "typst-ide",
  "typst-pdf",
  "typst-shim",
@@ -5818,7 +5811,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "typst",
- "typst-assets 0.14.2 (git+https://github.com/typst/typst-assets?rev=955ae8d)",
+ "typst-assets",
  "typst-ts-test-common",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6458,7 +6451,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ typst-html = "0.15.0"
 ttf-parser = "0.25.0"
 skrifa = "0.42.1"
 
-typst-assets = { git = "https://github.com/typst/typst-assets", rev = "955ae8d" }
+typst-assets = "0.15.0"
 typst-dev-assets = { git = "https://github.com/typst/typst-dev-assets", tag = "v0.15.0" }
 
 # general
@@ -193,12 +193,12 @@ vergen = { version = "9.0.1", features = [
 vergen-gitcl = { version = "9.1.0" }
 
 # tinymist's world implementation
-typst-shim = { version = "0.15.0-rc1", features = ["nightly"] }
-tinymist-std = { version = "0.15.0-rc1", default-features = false }
-tinymist-task = { version = "0.15.0-rc1", default-features = false }
-tinymist-world = { version = "0.15.0-rc1", default-features = false }
-tinymist-package = { version = "0.15.0-rc1", default-features = false }
-tinymist-project = { version = "0.15.0-rc1", default-features = false }
+typst-shim = { version = "0.15.0", features = ["nightly"] }
+tinymist-std = { version = "0.15.0", default-features = false }
+tinymist-task = { version = "0.15.0", default-features = false }
+tinymist-world = { version = "0.15.0", default-features = false }
+tinymist-package = { version = "0.15.0", default-features = false }
+tinymist-project = { version = "0.15.0", default-features = false }
 
 # project core
 reflexo = { version = "0.8.0-rc1", path = "crates/reflexo", default-features = false }
@@ -278,13 +278,13 @@ typst-bundle = { git = "https://github.com/Myriad-Dreamin/typst.git", tag = "typ
 
 # fontdb = { path = "../fontdb" }
 
-typst-shim = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-derive = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-std = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-task = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-package = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-world = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
-tinymist-project = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# typst-shim = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-derive = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-std = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-task = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-package = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-world = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
+# tinymist-project = { git = "https://github.com/Myriad-Dreamin/tinymist.git", rev = "692fca76e4e50f7ac462ba1c49646084627f0ef8" }
 
 # typst-shim = { path = "../tinymist/crates/typst-shim" }
 # tinymist-derive = { path = "../tinymist/crates/tinymist-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 description = "Run Typst in JavaScriptWorld."
 authors = ["Typst.ts Developers", "The Typst Project Developers"]
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"
@@ -201,22 +201,22 @@ tinymist-package = { version = "0.15.0", default-features = false }
 tinymist-project = { version = "0.15.0", default-features = false }
 
 # project core
-reflexo = { version = "0.8.0-rc1", path = "crates/reflexo", default-features = false }
-reflexo-typst = { version = "0.8.0-rc1", path = "crates/reflexo-typst" }
+reflexo = { version = "0.8.0-rc2", path = "crates/reflexo", default-features = false }
+reflexo-typst = { version = "0.8.0-rc2", path = "crates/reflexo-typst" }
 
 # conversions
-reflexo-typst2vec = { version = "0.8.0-rc1", path = "crates/conversion/typst2vec" }
-reflexo-typst2hast = { version = "0.8.0-rc1", path = "crates/conversion/typst2hast" }
-reflexo-vec2canvas = { version = "0.8.0-rc1", path = "crates/conversion/vec2canvas" }
-reflexo-vec2sema = { version = "0.8.0-rc1", path = "crates/conversion/vec2sema" }
-reflexo-vec2bbox = { version = "0.8.0-rc1", path = "crates/conversion/vec2bbox" }
-reflexo-vec2dom = { version = "0.8.0-rc1", path = "crates/conversion/vec2dom" }
-reflexo-vec2svg = { version = "0.8.0-rc1", path = "crates/conversion/vec2svg" }
+reflexo-typst2vec = { version = "0.8.0-rc2", path = "crates/conversion/typst2vec" }
+reflexo-typst2hast = { version = "0.8.0-rc2", path = "crates/conversion/typst2hast" }
+reflexo-vec2canvas = { version = "0.8.0-rc2", path = "crates/conversion/vec2canvas" }
+reflexo-vec2sema = { version = "0.8.0-rc2", path = "crates/conversion/vec2sema" }
+reflexo-vec2bbox = { version = "0.8.0-rc2", path = "crates/conversion/vec2bbox" }
+reflexo-vec2dom = { version = "0.8.0-rc2", path = "crates/conversion/vec2dom" }
+reflexo-vec2svg = { version = "0.8.0-rc2", path = "crates/conversion/vec2svg" }
 
 # project components
-typst-ts-test-common = { version = "0.8.0-rc1", path = "tests/common" }
-typst-ts-dev-server = { version = "0.8.0-rc1", path = "server/dev" }
-typst-ts-cli = { version = "0.8.0-rc1", path = "cli" }
+typst-ts-test-common = { version = "0.8.0-rc2", path = "tests/common" }
+typst-ts-dev-server = { version = "0.8.0-rc2", path = "server/dev" }
+typst-ts-cli = { version = "0.8.0-rc2", path = "cli" }
 
 [workspace.lints.rust]
 # missing_docs = "warn"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflexo-workspace",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "author": "Myriad-Dreamin",
   "description": "Run Typst in JavaScriptWorld.",
   "license": "Apache-2.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-web-compiler",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "WASM module for Compiling Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/enhanced-typst-svg/package.json
+++ b/packages/enhanced-typst-svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhanced-typst-svg",
   "private": true,
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "Typst svg enhancement",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-parser",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "WASM module for Parsing Typst documents in JavaScript environment.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-renderer",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "WASM module for rendering Typst documents in browser.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",

--- a/packages/typst-all-in-one.ts/package.json
+++ b/packages/typst-all-in-one.ts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@myriaddreamin/typst-all-in-one.ts",
-    "version": "0.8.0-rc1",
+    "version": "0.8.0-rc2",
     "description": "Run Typst in JavaScriptWorld with a single bundled library.",
     "author": "Myriad-Dreamin",
     "license": "Apache-2.0",
@@ -44,6 +44,6 @@
         "publish:lib": "npm publish --access public || exit 0"
     },
     "devDependencies": {
-        "@myriaddreamin/typst.ts": "*"
+        "@myriaddreamin/typst.ts": "0.8.0-rc2"
     }
 }

--- a/packages/typst.angular/package.json
+++ b/packages/typst.angular/package.json
@@ -27,8 +27,8 @@
     "zone.js": "~0.15.0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc1",
-    "@myriaddreamin/typst.ts": "^0.8.0-rc1"
+    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "^0.8.0-rc2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.5",
@@ -39,8 +39,8 @@
     "@angular-eslint/template-parser": "19.3.0",
     "@angular/cli": "~19.2.5",
     "@angular/compiler-cli": "^19.2.4",
-    "@myriaddreamin/typst-ts-renderer": "*",
-    "@myriaddreamin/typst.ts": "*",
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2",
     "@types/jasmine": "~5.1.6",
     "@types/web": "^0.0.188",
     "jasmine-core": "~5.6.0",

--- a/packages/typst.angular/projects/typst.angular/package.json
+++ b/packages/typst.angular/projects/typst.angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.angular",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
   "repository": {
@@ -19,8 +19,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst.ts": "^0.8.0-rc1",
-    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc1"
+    "@myriaddreamin/typst.ts": "^0.8.0-rc2",
+    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc2"
   },
   "sideEffects": false
 }

--- a/packages/typst.node/npm/android-arm-eabi/package.json
+++ b/packages/typst.node/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-android-arm-eabi",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "android"
   ],

--- a/packages/typst.node/npm/android-arm64/package.json
+++ b/packages/typst.node/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-android-arm64",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "android"
   ],

--- a/packages/typst.node/npm/darwin-arm64/package.json
+++ b/packages/typst.node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-darwin-arm64",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "darwin"
   ],

--- a/packages/typst.node/npm/darwin-x64/package.json
+++ b/packages/typst.node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-darwin-x64",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "darwin"
   ],

--- a/packages/typst.node/npm/linux-arm-gnueabihf/package.json
+++ b/packages/typst.node/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm-gnueabihf",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-arm64-gnu/package.json
+++ b/packages/typst.node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm64-gnu",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-arm64-musl/package.json
+++ b/packages/typst.node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-arm64-musl",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-x64-gnu/package.json
+++ b/packages/typst.node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-x64-gnu",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/linux-x64-musl/package.json
+++ b/packages/typst.node/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-linux-x64-musl",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "linux"
   ],

--- a/packages/typst.node/npm/win32-arm64-msvc/package.json
+++ b/packages/typst.node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-win32-arm64-msvc",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "win32"
   ],

--- a/packages/typst.node/npm/win32-x64-msvc/package.json
+++ b/packages/typst.node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler-win32-x64-msvc",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "os": [
     "win32"
   ],

--- a/packages/typst.node/package.json
+++ b/packages/typst.node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst-ts-node-compiler",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "author": "Myriad-Dreamin",
   "description": "Compile or Render Typst documents in Node environment.",
   "main": "index.js",

--- a/packages/typst.react/package.json
+++ b/packages/typst.react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.react",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "Typst.ts for React",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
@@ -42,14 +42,14 @@
     "publish:lib": "npm publish --access public || exit 0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc1",
-    "@myriaddreamin/typst.ts": "^0.8.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "^0.8.0-rc2",
     "react": "^17.0.1 || ^18.x || ^19.x",
     "react-dom": "^17.0.1 || ^18.x || ^19.x"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "*",
-    "@myriaddreamin/typst.ts": "*",
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "react": "^19.x",

--- a/packages/typst.solid/demo/package.json
+++ b/packages/typst.solid/demo/package.json
@@ -9,8 +9,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc1",
-    "@myriaddreamin/typst.ts": "0.8.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2",
     "solid-devtools": "^0.34.0",
     "typescript": "^5.8.3",
     "vite": "^6.2.3",

--- a/packages/typst.solid/package.json
+++ b/packages/typst.solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.solid",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "A SolidJS package for Typst integration.",
   "type": "module",
   "exports": {
@@ -21,8 +21,8 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc1",
-    "@myriaddreamin/typst.ts": "0.8.0-rc1",
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2",
     "solid-js": "^1.8.22",
     "vite-plugin-solid": "^2.11.6"
   },

--- a/packages/typst.svelte/package.json
+++ b/packages/typst.svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@myriaddreamin/typst.svelte",
-	"version": "0.8.0-rc1",
+	"version": "0.8.0-rc2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
@@ -32,14 +32,14 @@
 	},
 	"peerDependencies": {
 		"svelte": "^5.0.0",
-		"@myriaddreamin/typst-ts-renderer": "0.8.0-rc1",
-		"@myriaddreamin/typst-ts-web-compiler": "0.8.0-rc1",
-		"@myriaddreamin/typst.ts": "0.8.0-rc1"
+		"@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+		"@myriaddreamin/typst-ts-web-compiler": "0.8.0-rc2",
+		"@myriaddreamin/typst.ts": "0.8.0-rc2"
 	},
 	"devDependencies": {
-		"@myriaddreamin/typst-ts-renderer": "*",
-		"@myriaddreamin/typst-ts-web-compiler": "*",
-		"@myriaddreamin/typst.ts": "*",
+		"@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+		"@myriaddreamin/typst-ts-web-compiler": "0.8.0-rc2",
+		"@myriaddreamin/typst.ts": "0.8.0-rc2",
 		"playwright": "^1.52.0",
 		"typescript": "*",
 		"vite": "*",

--- a/packages/typst.ts/package.json
+++ b/packages/typst.ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.ts",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "Run Typst in JavaScriptWorld.",
   "author": "Myriad-Dreamin",
   "license": "Apache-2.0",
@@ -330,8 +330,8 @@
     "idb": "^7.1.1"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc1",
-    "@myriaddreamin/typst-ts-web-compiler": "^0.8.0-rc1"
+    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc2",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.8.0-rc2"
   },
   "peerDependenciesMeta": {
     "@myriaddreamin/typst-ts-renderer": {
@@ -342,8 +342,8 @@
     }
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "*",
-    "@myriaddreamin/typst-ts-web-compiler": "*",
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst-ts-web-compiler": "0.8.0-rc2",
     "@types/web": "^0.0.188",
     "builtin-modules": "3.3.0",
     "resolve.exports": "2.0.3",

--- a/packages/typst.vue3/package.json
+++ b/packages/typst.vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/typst.vue3",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
@@ -20,8 +20,8 @@
     "publish:lib": "npm publish --access public || exit 0"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc1",
-    "@myriaddreamin/typst.ts": "0.8.0-rc1"
+    "@myriaddreamin/typst-ts-renderer": "0.8.0-rc2",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2"
   },
   "peerDependencies": {
     "vue": "^3.4.31"

--- a/projects/hexo-renderer-typst/package.json
+++ b/projects/hexo-renderer-typst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-typst",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "Typst renderer plugin for Hexo",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
@@ -23,9 +23,9 @@
   },
   "peerDependencies": {
     "hexo": "^6",
-    "@myriaddreamin/typst.ts": "^0.8.0-rc1",
-    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc1",
-    "@myriaddreamin/typst-ts-node-compiler": "^0.8.0-rc1"
+    "@myriaddreamin/typst.ts": "^0.8.0-rc2",
+    "@myriaddreamin/typst-ts-renderer": "^0.8.0-rc2",
+    "@myriaddreamin/typst-ts-node-compiler": "^0.8.0-rc2"
   },
   "devDependencies": {},
   "scripts": {

--- a/projects/highlighter/package.json
+++ b/projects/highlighter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/highlighter-typst",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "typst code highlighting support in web",
   "author": "Myriad Dreamin <camiyoru@gmail.com>",
   "license": "Apache-2.0",
@@ -30,12 +30,12 @@
     "dist/**/*.{mts,mjs,cjs,cts,ts,js}"
   ],
   "peerDependencies": {
-    "@myriaddreamin/typst.ts": "^0.8.0-rc1",
-    "@myriaddreamin/typst-ts-parser": "^0.8.0-rc1"
+    "@myriaddreamin/typst.ts": "^0.8.0-rc2",
+    "@myriaddreamin/typst-ts-parser": "^0.8.0-rc2"
   },
   "devDependencies": {
-    "@myriaddreamin/typst.ts": "*",
-    "@myriaddreamin/typst-ts-parser": "*",
+    "@myriaddreamin/typst.ts": "0.8.0-rc2",
+    "@myriaddreamin/typst-ts-parser": "0.8.0-rc2",
     "vite": "^6.2.3",
     "vitest": "^3.0.9"
   },

--- a/projects/rehype-typst/package.json
+++ b/projects/rehype-typst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/rehype-typst",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "rehype plugin for rendering typst math equations",
   "main": "index.js",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "publish:lib": "npm publish --access public"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-node-compiler": "^0.8.0-rc1",
+    "@myriaddreamin/typst-ts-node-compiler": "^0.8.0-rc2",
     "@types/hast": "^3.0.0",
     "@types/katex": "^0.16.0",
     "hast-util-from-html-isomorphic": "^2.0.0",

--- a/projects/rustdoc-typst-demo/Cargo.toml
+++ b/projects/rustdoc-typst-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustdoc-typst-demo"
 description = "This project demonstrates an approach to including Typst in Rust docs"
-version = "0.8.0-rc1"
+version = "0.8.0-rc2"
 edition = "2021"
 authors = [
     "Paul Kernfeld <paulkernfeld@gmail.com>",

--- a/projects/vite-plugin-typst/package.json
+++ b/projects/vite-plugin-typst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriaddreamin/vite-plugin-typst",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0-rc2",
   "description": "Vite plugin for typst",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,7 +30,7 @@
     "glob-watcher": "^6.0.0"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst.node": "^0.8.0-rc1",
+    "@myriaddreamin/typst.node": "^0.8.0-rc2",
     "@xmldom/xmldom": "^0.9.8",
     "vite": "^6.2.3 || ^7.0.0"
   },


### PR DESCRIPTION
Bumps release metadata to v0.8.0-rc2 and keeps internal prerelease workspace dependencies resolved locally.