### PR TITLE
perf(renderer): reduce canvas renderer overhead

### DIFF
--- a/crates/conversion/vec2canvas/src/incr.rs
+++ b/crates/conversion/vec2canvas/src/incr.rs
@@ -4,6 +4,7 @@ use tiny_skia as sk;
 
 use reflexo::{
     error::prelude::*,
+    hash::Fingerprint,
     vector::{
         incr::IncrDocClient,
         ir::{ImmutStr, Module, Page, Rect},
@@ -119,14 +120,38 @@ pub struct IncrCanvasDocClient {
     /// Expected exact state of the current DOM.
     /// Initially it is None meaning no any page is rendered.
     pub doc_view: Option<Vec<Page>>,
+
+    /// Whether the vector document has received new data since the last canvas
+    /// interpretation.
+    doc_dirty: bool,
+
+    /// Page fingerprints for the last internal resource prefetch task.
+    prefetched_page_fingerprints: Vec<Fingerprint>,
+    prefetched_pixel_per_pt: f32,
+    resources_dirty: bool,
 }
 
 impl IncrCanvasDocClient {
     /// Reset the state of the incremental rendering.
-    pub fn reset(&mut self) {}
+    pub fn reset(&mut self) {
+        self.doc_view = None;
+        self.doc_dirty = true;
+        self.prefetched_page_fingerprints.clear();
+        self.prefetched_pixel_per_pt = 0.;
+        self.resources_dirty = true;
+    }
+
+    /// Marks the vector document as changed by a remote delta.
+    pub fn mark_delta_dirty(&mut self) {
+        self.doc_dirty = true;
+        self.resources_dirty = true;
+    }
 
     /// Set canvas's pixel per point
     pub fn set_pixel_per_pt(&mut self, pixel_per_pt: f32) {
+        if (self.vec2canvas.pixel_per_pt - pixel_per_pt).abs() >= f32::EPSILON {
+            self.resources_dirty = true;
+        }
         self.vec2canvas.pixel_per_pt = pixel_per_pt;
     }
 
@@ -136,13 +161,65 @@ impl IncrCanvasDocClient {
     }
 
     fn patch_delta(&mut self, kern: &IncrDocClient) {
+        if !self.doc_dirty {
+            return;
+        }
+
         if let Some(layout) = &kern.layout {
             let pages = layout.pages(&kern.doc.module);
             if let Some(pages) = pages {
-                self.vec2canvas
-                    .interpret_changes(pages.module(), pages.pages());
+                let next_doc_view = pages.pages();
+                if self.doc_view.as_deref() != Some(next_doc_view) {
+                    self.vec2canvas
+                        .interpret_changes(pages.module(), next_doc_view);
+                    self.doc_view = Some(next_doc_view.to_vec());
+                }
+
+                self.doc_dirty = false;
             }
         }
+    }
+
+    fn prefetch_page_resources(&mut self) {
+        let pixel_per_pt = self.vec2canvas.pixel_per_pt;
+        let pixel_changed = (self.prefetched_pixel_per_pt - pixel_per_pt).abs() >= f32::EPSILON;
+        if !self.resources_dirty && !pixel_changed {
+            return;
+        }
+
+        let page_count = self.vec2canvas.pages.len();
+        if page_count == 0 {
+            self.prefetched_page_fingerprints.clear();
+            self.prefetched_pixel_per_pt = pixel_per_pt;
+            self.resources_dirty = false;
+            return;
+        }
+
+        let mut page_fingerprints = Vec::with_capacity(page_count);
+        let mut indices = Vec::new();
+        for (idx, page) in self.vec2canvas.pages.iter().enumerate() {
+            page_fingerprints.push(page.content);
+            if pixel_changed || self.prefetched_page_fingerprints.get(idx) != Some(&page.content) {
+                indices.push(idx);
+            }
+        }
+
+        self.prefetched_page_fingerprints = page_fingerprints;
+        self.prefetched_pixel_per_pt = pixel_per_pt;
+        self.resources_dirty = false;
+
+        if indices.is_empty() {
+            return;
+        }
+
+        let ts = sk::Transform::from_scale(pixel_per_pt, pixel_per_pt);
+        let Ok(Some(prepare)) = self.vec2canvas.prepare_pages(&indices, ts) else {
+            return;
+        };
+
+        wasm_bindgen_futures::spawn_local(async move {
+            prepare.await;
+        });
     }
 
     /// Render a specific page of the document in the given window.
@@ -154,6 +231,7 @@ impl IncrCanvasDocClient {
         _rect: Rect,
     ) -> Result<()> {
         self.patch_delta(kern);
+        self.prefetch_page_resources();
 
         if idx >= self.vec2canvas.pages.len() {
             Err(error_once!("Renderer.OutofPageRange", idx: idx))?;

--- a/crates/conversion/vec2canvas/src/lib.rs
+++ b/crates/conversion/vec2canvas/src/lib.rs
@@ -22,6 +22,7 @@ use web_sys::{Blob, HtmlImageElement, OffscreenCanvas, OffscreenCanvasRenderingC
 
 use std::{
     cell::OnceCell,
+    collections::HashMap,
     fmt::Debug,
     sync::{Arc, Mutex},
 };
@@ -143,6 +144,7 @@ impl<Feat: ExportFeature> CanvasTask<Feat> {
             module,
 
             use_stable_glyph_id: true,
+            glyph_cache: HashMap::new(),
 
             _feat_phantom: Default::default(),
         }
@@ -165,7 +167,16 @@ pub struct CanvasRenderTask<'m, 't, Feat: ExportFeature> {
     /// See [`ExportFeature`].
     pub use_stable_glyph_id: bool,
 
+    glyph_cache: HashMap<CanvasGlyphCacheKey, CanvasNode>,
+
     _feat_phantom: std::marker::PhantomData<&'t Feat>,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+struct CanvasGlyphCacheKey {
+    font: Fingerprint,
+    glyph: u32,
+    fill: ImmutStr,
 }
 
 impl<'m, Feat: ExportFeature> FontIndice<'m> for CanvasRenderTask<'m, '_, Feat> {
@@ -176,11 +187,33 @@ impl<'m, Feat: ExportFeature> FontIndice<'m> for CanvasRenderTask<'m, '_, Feat> 
 
 impl<Feat: ExportFeature> GlyphFactory for CanvasRenderTask<'_, '_, Feat> {
     fn get_glyph(&mut self, font: &FontItem, glyph: u32, fill: CanvasPaint) -> Option<CanvasNode> {
+        if let CanvasPaint::Solid(fill_color) = fill {
+            let key = CanvasGlyphCacheKey {
+                font: font.fingerprint,
+                glyph,
+                fill: fill_color.clone(),
+            };
+            if let Some(cached) = self.glyph_cache.get(&key) {
+                return Some(cached.clone());
+            }
+
+            let glyph_data = font.get_glyph(glyph)?;
+            let node = Arc::new(CanvasElem::Glyph(CanvasGlyphElem {
+                fill: CanvasPaint::Solid(fill_color),
+                upem: font.units_per_em,
+                glyph_data: glyph_data.clone(),
+                path: Default::default(),
+            }));
+            self.glyph_cache.insert(key, node.clone());
+            return Some(node);
+        }
+
         let glyph_data = font.get_glyph(glyph)?;
         Some(Arc::new(CanvasElem::Glyph(CanvasGlyphElem {
             fill,
             upem: font.units_per_em,
             glyph_data: glyph_data.clone(),
+            path: Default::default(),
         })))
     }
 
@@ -277,6 +310,7 @@ impl From<CanvasStack> for CanvasNode {
                 d: clipper.d,
                 inner,
                 clip_bbox: CanvasBBox::Dynamic(Box::new(OnceCell::new())),
+                path: Default::default(),
             }))
         } else {
             inner
@@ -340,6 +374,7 @@ impl<'m, C: RenderVm<'m, Resultant = CanvasNode> + GlyphFactory> GroupContext<C>
                     _ => None,
                 }),
                 rect: CanvasBBox::Dynamic(Box::new(OnceCell::new())),
+                path: Default::default(),
             })),
         ))
     }

--- a/crates/conversion/vec2canvas/src/ops.rs
+++ b/crates/conversion/vec2canvas/src/ops.rs
@@ -165,11 +165,80 @@ impl CanvasOp for CanvasGroupElem {
     async fn realize(&self, rts: sk::Transform, canvas: &dyn CanvasDevice) {
         let ts = rts.pre_concat(*self.ts.as_ref());
 
+        #[cfg(not(feature = "rasterize_glyph"))]
+        if matches!(self.kind, GroupKind::Text) && self.realize_solid_text_run(ts, canvas) {
+            self.realize_debug(rts, ts, canvas);
+            return;
+        }
+
+        self.realize_inner(ts, canvas).await;
+        self.realize_debug(rts, ts, canvas);
+    }
+}
+
+impl CanvasGroupElem {
+    #[cfg(not(feature = "rasterize_glyph"))]
+    fn realize_solid_text_run(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) -> bool {
+        let Some(fill) = self.solid_text_run_fill() else {
+            return false;
+        };
+
+        let _guard = CanvasStateGuard::new(canvas);
+        canvas.set_fill_style_str(fill);
+        for (pos, sub_elem) in &self.inner {
+            let sub_ts = ts.pre_translate(pos.x.0, pos.y.0);
+
+            let CanvasElem::Glyph(glyph) = sub_elem.as_ref() else {
+                return false;
+            };
+            let FlatGlyphItem::Outline(path) = glyph.glyph_data.as_ref() else {
+                continue;
+            };
+            if !set_transform(canvas, sub_ts) {
+                continue;
+            }
+
+            let path = glyph.path.get_or_init(&path.d);
+            canvas.fill_with_path_2d(path);
+        }
+
+        true
+    }
+
+    #[cfg(not(feature = "rasterize_glyph"))]
+    fn solid_text_run_fill(&self) -> Option<&str> {
+        let mut fill: Option<&str> = None;
+        for (_, sub_elem) in &self.inner {
+            let CanvasElem::Glyph(glyph) = sub_elem.as_ref() else {
+                return None;
+            };
+
+            match glyph.glyph_data.as_ref() {
+                FlatGlyphItem::Outline(_) | FlatGlyphItem::None => {}
+                FlatGlyphItem::Image(_) => return None,
+            }
+
+            let glyph_fill = glyph.fill.as_solid_str()?;
+            if let Some(fill) = fill {
+                if fill != glyph_fill {
+                    return None;
+                }
+            } else {
+                fill = Some(glyph_fill);
+            }
+        }
+
+        fill
+    }
+
+    async fn realize_inner(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
         for (pos, sub_elem) in &self.inner {
             let ts = ts.pre_translate(pos.x.0, pos.y.0);
             sub_elem.realize(ts, canvas).await;
         }
+    }
 
+    fn realize_debug(&self, rts: sk::Transform, ts: sk::Transform, canvas: &dyn CanvasDevice) {
         let _ = self.rect;
         let _ = Self::bbox_at;
         #[cfg(feature = "report_group")]

--- a/crates/conversion/vec2canvas/src/ops.rs
+++ b/crates/conversion/vec2canvas/src/ops.rs
@@ -7,7 +7,8 @@ use crate::{utils::EmptyFuture, CanvasDevice, CanvasPaint};
 use ecow::EcoVec;
 
 use std::{
-    fmt::Debug,
+    cell::OnceCell,
+    fmt::{self, Debug, Formatter},
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -26,6 +27,24 @@ use reflexo::vector::ir::{
 };
 
 use super::{rasterize_image, set_transform, BBoxAt, CanvasBBox, CanvasStateGuard};
+
+#[derive(Default)]
+pub struct CachedPath2d(OnceCell<Path2d>);
+
+impl CachedPath2d {
+    fn get_or_init(&self, d: &str) -> &Path2d {
+        self.0
+            .get_or_init(|| Path2d::new_with_path_string(d).unwrap())
+    }
+}
+
+impl Debug for CachedPath2d {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CachedPath2d")
+            .field("initialized", &self.0.get().is_some())
+            .finish()
+    }
+}
 
 /// A reference to a canvas element.
 pub type CanvasNode = Arc<CanvasElem>;
@@ -182,6 +201,7 @@ pub struct CanvasClipElem {
     pub d: ImmutStr,
     pub inner: CanvasNode,
     pub clip_bbox: CanvasBBox,
+    pub path: CachedPath2d,
 }
 
 impl CanvasClipElem {
@@ -200,7 +220,7 @@ impl CanvasClipElem {
         if !set_transform(canvas, ts) {
             return guard;
         }
-        canvas.clip_with_path_2d(&Path2d::new_with_path_string(&self.d).unwrap());
+        canvas.clip_with_path_2d(self.path.get_or_init(&self.d));
 
         guard
     }
@@ -229,6 +249,7 @@ pub struct CanvasPathElem {
     pub fill: Option<CanvasPaint>,
     pub stroke: Option<CanvasPaint>,
     pub rect: CanvasBBox,
+    pub path: CachedPath2d,
 }
 
 #[async_trait(?Send)]
@@ -287,7 +308,7 @@ impl CanvasOp for CanvasPathElem {
             }
         }
 
-        let path = Path2d::new_with_path_string(&self.path_data.d).unwrap();
+        let path = self.path.get_or_init(&self.path_data.d);
 
         if let Some(fill) = &self.fill {
             if fill.fill_radial_path(canvas, ts, &path) {
@@ -413,6 +434,7 @@ pub struct CanvasGlyphElem {
     pub fill: CanvasPaint,
     pub upem: Scalar,
     pub glyph_data: Arc<FlatGlyphItem>,
+    pub path: CachedPath2d,
 }
 
 #[async_trait(?Send)]
@@ -445,7 +467,7 @@ impl CanvasOp for CanvasGlyphElem {
                     return;
                 }
 
-                let path = Path2d::new_with_path_string(&path.d).unwrap();
+                let path = self.path.get_or_init(&path.d);
                 if self.fill.fill_conic_path(canvas, ts, &path, false) {
                     return;
                 }
@@ -462,7 +484,7 @@ impl CanvasOp for CanvasGlyphElem {
                     return;
                 }
 
-                let path_2d = Path2d::new_with_path_string(&path.d).unwrap();
+                let path_2d = self.path.get_or_init(&path.d);
                 if self.fill.fill_conic_path(canvas, ts, &path_2d, false) {
                     return;
                 }

--- a/packages/renderer/src/render/canvas.rs
+++ b/packages/renderer/src/render/canvas.rs
@@ -1,9 +1,9 @@
+use std::collections::HashMap;
 use std::sync::OnceLock;
-use std::{collections::HashMap, ops::Deref};
 
 use reflexo_typst::error::prelude::*;
 use reflexo_typst::hash::Fingerprint;
-use reflexo_typst::vector::ir::{Axes, LayoutRegionNode, Rect, Scalar};
+use reflexo_typst::vector::ir::{Axes, Rect, Scalar};
 use reflexo_vec2canvas::{BrowserFontMetric, CanvasDevice, DefaultExportFeature, ExportFeature};
 use reflexo_vec2sema::SemaTask;
 use wasm_bindgen::prelude::*;
@@ -95,11 +95,12 @@ impl TypstRenderer {
         let pages = t.pages(kern.module()).unwrap().pages();
 
         let page_num = opts.page_off;
-        let fingerprint = if let Some(page) = pages.get(page_num) {
-            page.content
+        let page = if let Some(page) = pages.get(page_num) {
+            page.clone()
         } else {
             return Err(error_once!("Renderer.MissingPage", idx: page_num));
         };
+        let fingerprint = page.content;
 
         if should_render_body {
             let cached = opts
@@ -132,30 +133,14 @@ impl TypstRenderer {
             }
         }
 
-        // todo: leaking abstraction
-        // todo: reuse
-        if let Some(t) = &kern.layout {
-            let pages = match t {
-                LayoutRegionNode::Pages(a) => {
-                    let (_, pages) = a.deref();
-                    pages
-                }
-                _ => todo!(),
-            };
-            for (idx, page) in pages.iter().enumerate() {
-                if page_num != idx {
-                    continue;
-                }
-                if let Some(worker) = tc.as_mut() {
-                    let metric = FONT_METRICS.get_or_init(BrowserFontMetric::from_env);
+        if let Some(worker) = tc.as_mut() {
+            let metric = FONT_METRICS.get_or_init(BrowserFontMetric::from_env);
 
-                    let mut output = vec![];
-                    let mut t = SemaTask::new(true, *metric, page.size.x.0, page.size.y.0);
-                    let ts = tiny_skia::Transform::identity();
-                    t.render_semantics(&kern.doc.module, ts, page.content, &mut output);
-                    worker.push(output.concat());
-                }
-            }
+            let mut output = vec![];
+            let mut t = SemaTask::new(true, *metric, page.size.x.0, page.size.y.0);
+            let ts = tiny_skia::Transform::identity();
+            t.render_semantics(&kern.doc.module, ts, page.content, &mut output);
+            worker.push(output.concat());
         }
 
         Ok((

--- a/packages/renderer/src/session.rs
+++ b/packages/renderer/src/session.rs
@@ -258,8 +258,20 @@ impl RenderSession {
     }
 
     pub(crate) fn merge_delta(&mut self, delta: &[u8]) -> Result<()> {
-        let mut client = self.client.lock().unwrap();
-        Self::merge_delta_inner(&mut self.pages_info, &mut client, delta)
+        let res = {
+            let mut client = self.client.lock().unwrap();
+            Self::merge_delta_inner(&mut self.pages_info, &mut client, delta)
+        };
+
+        if res.is_ok() {
+            #[cfg(feature = "render_canvas")]
+            {
+                let mut canvas_kern = self.canvas_kern.lock().unwrap();
+                canvas_kern.mark_delta_dirty();
+            }
+        }
+
+        res
     }
 
     pub(crate) fn merge_delta_inner(


### PR DESCRIPTION
- Reduce default canvas text-run overhead for same-solid-fill glyph groups.
- Keep bitmap-cache feature paths unchanged.