### PR TITLE
perf(renderer): support windowed canvas rendering

### DIFF
--- a/crates/conversion/vec2canvas/Cargo.toml
+++ b/crates/conversion/vec2canvas/Cargo.toml
@@ -51,6 +51,9 @@ incremental = ["reflexo/flat-vector"]
 report_group = []
 render_bbox = []
 rasterize_glyph = []
+bitmap_cache_word = []
+bitmap_cache_line = []
+bitmap_cache_paragraph = []
 
 [lints]
 workspace = true

--- a/crates/conversion/vec2canvas/src/bounds.rs
+++ b/crates/conversion/vec2canvas/src/bounds.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::cell::OnceCell;
 
 use elsa::FrozenMap;
-use reflexo::vector::ir::{self, Rect, Scalar};
+use reflexo::vector::ir::{self, FlatGlyphItem, Rect, Scalar};
 use tiny_skia as sk;
 
 use crate::ops::*;
@@ -123,7 +123,64 @@ impl BBoxAt for CanvasImageElem {
 }
 
 impl BBoxAt for CanvasGlyphElem {
-    fn bbox_at(&self, _ts: sk::Transform) -> Option<Rect> {
-        None
+    fn bbox_at(&self, ts: sk::Transform) -> Option<Rect> {
+        let rect = self
+            .bbox
+            .get_or_init(|| glyph_local_bbox(self.glyph_data.as_ref()));
+        transform_rect((*rect)?, ts)
     }
+}
+
+fn glyph_local_bbox(glyph: &FlatGlyphItem) -> Option<Rect> {
+    match glyph {
+        FlatGlyphItem::None => None,
+        FlatGlyphItem::Image(image) => {
+            let rect = sk::Rect::from_xywh(0., 0., image.image.size.x.0, image.image.size.y.0)?;
+            rect.transform(image.ts.into()).map(From::from)
+        }
+        FlatGlyphItem::Outline(outline) => {
+            let mut path = convert_path(&outline.d)?;
+            if let Some(transform) = &outline.ts {
+                let transform: tiny_skia_path::Transform = (**transform).into();
+                path = path.transform(transform)?;
+            }
+
+            Some(path.bounds().into())
+        }
+    }
+}
+
+fn transform_rect(rect: Rect, ts: sk::Transform) -> Option<Rect> {
+    sk::Rect::from_xywh(rect.lo.x.0, rect.lo.y.0, rect.width().0, rect.height().0)
+        .and_then(|rect| rect.transform(ts))
+        .map(From::from)
+}
+
+fn convert_path(path_data: &str) -> Option<tiny_skia_path::Path> {
+    let mut builder = tiny_skia_path::PathBuilder::new();
+
+    for segment in svgtypes::SimplifyingPathParser::from(path_data) {
+        let segment = segment.ok()?;
+
+        match segment {
+            svgtypes::SimplePathSegment::MoveTo { x, y } => builder.move_to(x as f32, y as f32),
+            svgtypes::SimplePathSegment::LineTo { x, y } => builder.line_to(x as f32, y as f32),
+            svgtypes::SimplePathSegment::Quadratic { x1, y1, x, y } => {
+                builder.quad_to(x1 as f32, y1 as f32, x as f32, y as f32)
+            }
+            svgtypes::SimplePathSegment::CurveTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x,
+                y,
+            } => builder.cubic_to(
+                x1 as f32, y1 as f32, x2 as f32, y2 as f32, x as f32, y as f32,
+            ),
+            svgtypes::SimplePathSegment::ClosePath => builder.close(),
+        }
+    }
+
+    builder.finish()
 }

--- a/crates/conversion/vec2canvas/src/incr.rs
+++ b/crates/conversion/vec2canvas/src/incr.rs
@@ -7,7 +7,7 @@ use reflexo::{
     hash::Fingerprint,
     vector::{
         incr::IncrDocClient,
-        ir::{ImmutStr, Module, Page, Rect},
+        ir::{ImmutStr, Module, Page, Point, Rect, Scalar},
         vm::RenderVm,
     },
 };
@@ -90,7 +90,15 @@ impl IncrVec2CanvasPass {
             return;
         }
         canvas.set_fill_style_str(self.fill.as_ref());
-        canvas.fill_rect(0., 0., pg.size.x.0 as f64, pg.size.y.0 as f64);
+        let fill_rect = rect
+            .and_then(|rect| intersect_rect(rect, page_rect(pg.size)))
+            .unwrap_or_else(|| page_rect(pg.size));
+        canvas.fill_rect(
+            fill_rect.left().0 as f64,
+            fill_rect.top().0 as f64,
+            fill_rect.width().0 as f64,
+            fill_rect.height().0 as f64,
+        );
 
         let window = rect.and_then(|rect| transform_rect(rect, ts));
         pg.elem
@@ -280,6 +288,29 @@ impl IncrCanvasDocClient {
 
 fn is_full_render_rect(rect: Rect) -> bool {
     rect.lo.x.0 <= -1.0 && rect.lo.y.0 <= -1.0 && rect.hi.x.0 >= 1e20 && rect.hi.y.0 >= 1e20
+}
+
+fn page_rect(size: Point) -> Rect {
+    Rect {
+        lo: Point::new(Scalar(0.), Scalar(0.)),
+        hi: size,
+    }
+}
+
+fn intersect_rect(a: Rect, b: Rect) -> Option<Rect> {
+    let lo_x = a.left().0.max(b.left().0);
+    let lo_y = a.top().0.max(b.top().0);
+    let hi_x = a.right().0.min(b.right().0);
+    let hi_y = a.bottom().0.min(b.bottom().0);
+
+    if hi_x <= lo_x || hi_y <= lo_y {
+        return None;
+    }
+
+    Some(Rect {
+        lo: Point::new(Scalar(lo_x), Scalar(lo_y)),
+        hi: Point::new(Scalar(hi_x), Scalar(hi_y)),
+    })
 }
 
 fn transform_rect(rect: Rect, ts: sk::Transform) -> Option<Rect> {

--- a/crates/conversion/vec2canvas/src/incr.rs
+++ b/crates/conversion/vec2canvas/src/incr.rs
@@ -12,7 +12,10 @@ use reflexo::{
     },
 };
 
-use crate::{set_transform, CanvasDevice, CanvasOp, CanvasPage, CanvasTask, DefaultExportFeature};
+use crate::{
+    set_transform, CanvasDevice, CanvasOp, CanvasPage, CanvasRenderContext, CanvasTask,
+    DefaultExportFeature,
+};
 
 /// Prepared canvas resources that can be awaited after the document locks are
 /// released.
@@ -70,6 +73,17 @@ impl IncrVec2CanvasPass {
 
     /// Flushes a page to the canvas with the given transform.
     pub async fn flush_page(&mut self, idx: usize, canvas: &dyn CanvasDevice, ts: sk::Transform) {
+        self.flush_page_in_window(idx, canvas, ts, None).await
+    }
+
+    /// Flushes a page to the canvas with an optional page-local render window.
+    pub async fn flush_page_in_window(
+        &mut self,
+        idx: usize,
+        canvas: &dyn CanvasDevice,
+        ts: sk::Transform,
+        rect: Option<Rect>,
+    ) {
         let pg = &self.pages[idx];
 
         if !set_transform(canvas, ts) {
@@ -78,7 +92,10 @@ impl IncrVec2CanvasPass {
         canvas.set_fill_style_str(self.fill.as_ref());
         canvas.fill_rect(0., 0., pg.size.x.0 as f64, pg.size.y.0 as f64);
 
-        pg.elem.realize(ts, canvas).await;
+        let window = rect.and_then(|rect| transform_rect(rect, ts));
+        pg.elem
+            .realize(ts, canvas, CanvasRenderContext::new(window))
+            .await;
     }
 
     /// Starts preparation of external resources used by the selected pages.
@@ -228,7 +245,7 @@ impl IncrCanvasDocClient {
         kern: &mut IncrDocClient,
         canvas: &dyn CanvasDevice,
         idx: usize,
-        _rect: Rect,
+        rect: Rect,
     ) -> Result<()> {
         self.patch_delta(kern);
         self.prefetch_page_resources();
@@ -239,7 +256,10 @@ impl IncrCanvasDocClient {
 
         let s = self.vec2canvas.pixel_per_pt;
         let ts = sk::Transform::from_scale(s, s);
-        self.vec2canvas.flush_page(idx, canvas, ts).await;
+        let rect = (!is_full_render_rect(rect)).then_some(rect);
+        self.vec2canvas
+            .flush_page_in_window(idx, canvas, ts, rect)
+            .await;
 
         Ok(())
     }
@@ -256,4 +276,14 @@ impl IncrCanvasDocClient {
         let ts = sk::Transform::from_scale(s, s);
         self.vec2canvas.prepare_pages(indices, ts)
     }
+}
+
+fn is_full_render_rect(rect: Rect) -> bool {
+    rect.lo.x.0 <= -1.0 && rect.lo.y.0 <= -1.0 && rect.hi.x.0 >= 1e20 && rect.hi.y.0 >= 1e20
+}
+
+fn transform_rect(rect: Rect, ts: sk::Transform) -> Option<Rect> {
+    sk::Rect::from_ltrb(rect.left().0, rect.top().0, rect.right().0, rect.bottom().0)
+        .and_then(|rect| rect.transform(ts))
+        .map(From::from)
 }

--- a/crates/conversion/vec2canvas/src/lib.rs
+++ b/crates/conversion/vec2canvas/src/lib.rs
@@ -304,6 +304,8 @@ impl From<CanvasStack> for CanvasNode {
             inner: s.inner,
             kind: s.kind,
             rect: s.rect,
+            #[cfg(feature = "bitmap_cache_word")]
+            bitmap_cache: Default::default(),
         }));
         if let Some(clipper) = s.clipper {
             Arc::new(CanvasElem::Clip(CanvasClipElem {

--- a/crates/conversion/vec2canvas/src/lib.rs
+++ b/crates/conversion/vec2canvas/src/lib.rs
@@ -203,6 +203,7 @@ impl<Feat: ExportFeature> GlyphFactory for CanvasRenderTask<'_, '_, Feat> {
                 upem: font.units_per_em,
                 glyph_data: glyph_data.clone(),
                 path: Default::default(),
+                bbox: Default::default(),
             }));
             self.glyph_cache.insert(key, node.clone());
             return Some(node);
@@ -214,6 +215,7 @@ impl<Feat: ExportFeature> GlyphFactory for CanvasRenderTask<'_, '_, Feat> {
             upem: font.units_per_em,
             glyph_data: glyph_data.clone(),
             path: Default::default(),
+            bbox: Default::default(),
         })))
     }
 

--- a/crates/conversion/vec2canvas/src/ops.rs
+++ b/crates/conversion/vec2canvas/src/ops.rs
@@ -7,7 +7,8 @@ use crate::{utils::EmptyFuture, CanvasDevice, CanvasPaint};
 use ecow::EcoVec;
 
 use std::{
-    cell::OnceCell,
+    cell::{Cell, OnceCell, RefCell},
+    collections::HashMap,
     fmt::{self, Debug, Formatter},
     pin::Pin,
     sync::{
@@ -20,13 +21,34 @@ use js_sys::Promise;
 use tiny_skia as sk;
 
 use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
-use web_sys::{CanvasWindingRule, ImageBitmap, OffscreenCanvas, Path2d};
+use web_sys::{
+    CanvasWindingRule, ImageBitmap, OffscreenCanvas, OffscreenCanvasRenderingContext2d, Path2d,
+};
 
 use reflexo::vector::ir::{
     self, FlatGlyphItem, Image, ImageItem, ImmutStr, PathStyle, Rect, Scalar,
 };
 
 use super::{rasterize_image, set_transform, BBoxAt, CanvasBBox, CanvasStateGuard};
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+const BITMAP_CACHE_PADDING: f32 = 2.0;
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+const BITMAP_CACHE_MAX_DIMENSION: f32 = 4096.0;
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+const BITMAP_CACHE_MAX_AREA: f32 = 16_000_000.0;
 
 #[derive(Default)]
 pub struct CachedPath2d(OnceCell<Path2d>);
@@ -46,6 +68,34 @@ impl Debug for CachedPath2d {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CanvasRenderContext {
+    window: Option<Rect>,
+}
+
+impl CanvasRenderContext {
+    pub fn new(window: Option<Rect>) -> Self {
+        Self { window }
+    }
+
+    fn render_window_intersects(self, node: &CanvasNode, ts: sk::Transform) -> bool {
+        let Some(window) = self.window else {
+            return true;
+        };
+
+        node.bbox_at(ts)
+            .map(|bbox| rect_intersects(bbox, window))
+            .unwrap_or(true)
+    }
+}
+
+fn rect_intersects(a: Rect, b: Rect) -> bool {
+    a.left().0 <= b.right().0
+        && a.right().0 >= b.left().0
+        && a.top().0 <= b.bottom().0
+        && a.bottom().0 >= b.top().0
+}
+
 /// A reference to a canvas element.
 pub type CanvasNode = Arc<CanvasElem>;
 /// 2d Context
@@ -61,7 +111,7 @@ pub trait CanvasOp {
         ts: sk::Transform,
     ) -> Option<impl core::future::Future<Output = ()> + Sized + 'static>;
     /// Realizes the action on the canvas.
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice);
+    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice, ctx: CanvasRenderContext);
 }
 
 /// A static enum for all the canvas elements.
@@ -111,13 +161,18 @@ impl CanvasOp for CanvasElem {
         }
     }
 
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) {
         match self {
-            CanvasElem::Group(g) => g.realize(ts, canvas).await,
-            CanvasElem::Clip(g) => g.realize(ts, canvas).await,
-            CanvasElem::Path(g) => g.realize(ts, canvas).await,
-            CanvasElem::Image(g) => g.realize(ts, canvas).await,
-            CanvasElem::Glyph(g) => g.realize(ts, canvas).await,
+            CanvasElem::Group(g) => g.realize(ts, canvas, ctx).await,
+            CanvasElem::Clip(g) => g.realize(ts, canvas, ctx).await,
+            CanvasElem::Path(g) => g.realize(ts, canvas, ctx).await,
+            CanvasElem::Image(g) => g.realize(ts, canvas, ctx).await,
+            CanvasElem::Glyph(g) => g.realize(ts, canvas, ctx).await,
         }
     }
 }
@@ -135,6 +190,8 @@ pub struct CanvasGroupElem {
     pub inner: EcoVec<(ir::Point, CanvasNode)>,
     pub kind: GroupKind,
     pub rect: CanvasBBox,
+    #[cfg(feature = "bitmap_cache_word")]
+    pub bitmap_cache: RefCell<Option<GroupBitmapCache>>,
 }
 
 #[async_trait(?Send)]
@@ -162,23 +219,48 @@ impl CanvasOp for CanvasGroupElem {
         }
     }
 
-    async fn realize(&self, rts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        rts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) {
         let ts = rts.pre_concat(*self.ts.as_ref());
 
-        #[cfg(not(feature = "rasterize_glyph"))]
-        if matches!(self.kind, GroupKind::Text) && self.realize_solid_text_run(ts, canvas) {
+        #[cfg(feature = "bitmap_cache_word")]
+        if bitmap_cache_enabled() && matches!(self.kind, GroupKind::Text) {
+            if self.realize_group_bitmap(rts, ts, canvas, ctx).await {
+                return;
+            }
+        }
+
+        #[cfg(any(feature = "bitmap_cache_line", feature = "bitmap_cache_paragraph"))]
+        if bitmap_cache_enabled() && matches!(self.kind, GroupKind::General) {
+            self.realize_inner_with_text_bitmap_spans(ts, canvas, ctx)
+                .await;
             self.realize_debug(rts, ts, canvas);
             return;
         }
 
-        self.realize_inner(ts, canvas).await;
+        #[cfg(not(feature = "rasterize_glyph"))]
+        if matches!(self.kind, GroupKind::Text) && self.realize_solid_text_run(ts, canvas, ctx) {
+            self.realize_debug(rts, ts, canvas);
+            return;
+        }
+
+        self.realize_inner(ts, canvas, ctx).await;
         self.realize_debug(rts, ts, canvas);
     }
 }
 
 impl CanvasGroupElem {
     #[cfg(not(feature = "rasterize_glyph"))]
-    fn realize_solid_text_run(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) -> bool {
+    fn realize_solid_text_run(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) -> bool {
         let Some(fill) = self.solid_text_run_fill() else {
             return false;
         };
@@ -187,6 +269,9 @@ impl CanvasGroupElem {
         canvas.set_fill_style_str(fill);
         for (pos, sub_elem) in &self.inner {
             let sub_ts = ts.pre_translate(pos.x.0, pos.y.0);
+            if !ctx.render_window_intersects(sub_elem, sub_ts) {
+                continue;
+            }
 
             let CanvasElem::Glyph(glyph) = sub_elem.as_ref() else {
                 return false;
@@ -231,10 +316,18 @@ impl CanvasGroupElem {
         fill
     }
 
-    async fn realize_inner(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize_inner(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) {
         for (pos, sub_elem) in &self.inner {
             let ts = ts.pre_translate(pos.x.0, pos.y.0);
-            sub_elem.realize(ts, canvas).await;
+            if !ctx.render_window_intersects(sub_elem, ts) {
+                continue;
+            }
+            sub_elem.realize(ts, canvas, ctx).await;
         }
     }
 
@@ -262,6 +355,425 @@ impl CanvasGroupElem {
             web_sys::console::log_1(&format!("realize group bbox {:?} {:?}", ts, bbox).into());
         }
     }
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+#[derive(Debug)]
+pub struct GroupBitmapCache {
+    key: BitmapCacheKey,
+    bitmap: CachedBitmap,
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+#[derive(Debug)]
+struct CachedBitmap {
+    canvas: OffscreenCanvas,
+    width: u32,
+    height: u32,
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+struct BitmapCacheKey {
+    sx: i32,
+    ky: i32,
+    kx: i32,
+    sy: i32,
+    tx: i32,
+    ty: i32,
+    width: u32,
+    height: u32,
+}
+
+#[cfg(any(feature = "bitmap_cache_line", feature = "bitmap_cache_paragraph"))]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+struct SpanBitmapCacheKey {
+    group: usize,
+    start: usize,
+    end: usize,
+    bitmap: BitmapCacheKey,
+}
+
+#[cfg(any(feature = "bitmap_cache_line", feature = "bitmap_cache_paragraph"))]
+thread_local! {
+    static SPAN_BITMAP_CACHE: RefCell<HashMap<SpanBitmapCacheKey, CachedBitmap>> =
+        RefCell::new(HashMap::new());
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+thread_local! {
+    static BITMAP_CACHE_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+struct BitmapCacheScope;
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+impl BitmapCacheScope {
+    fn new() -> Self {
+        BITMAP_CACHE_DEPTH.with(|depth| depth.set(depth.get() + 1));
+        Self
+    }
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+impl Drop for BitmapCacheScope {
+    fn drop(&mut self) {
+        BITMAP_CACHE_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+fn bitmap_cache_enabled() -> bool {
+    BITMAP_CACHE_DEPTH.with(|depth| depth.get() == 0)
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+fn bitmap_cache_key(ts: sk::Transform, bbox: Rect, width: u32, height: u32) -> BitmapCacheKey {
+    fn q(v: f32) -> i32 {
+        (v * 1024.0).round() as i32
+    }
+
+    BitmapCacheKey {
+        sx: q(ts.sx),
+        ky: q(ts.ky),
+        kx: q(ts.kx),
+        sy: q(ts.sy),
+        tx: q(ts.tx + bbox.left().0),
+        ty: q(ts.ty + bbox.top().0),
+        width,
+        height,
+    }
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+fn bitmap_dimensions(bbox: Rect) -> Option<(u32, u32)> {
+    let width = bbox.width().0 + BITMAP_CACHE_PADDING * 2.0;
+    let height = bbox.height().0 + BITMAP_CACHE_PADDING * 2.0;
+    if width <= 0.0
+        || height <= 0.0
+        || width > BITMAP_CACHE_MAX_DIMENSION
+        || height > BITMAP_CACHE_MAX_DIMENSION
+        || width * height > BITMAP_CACHE_MAX_AREA
+    {
+        return None;
+    }
+
+    Some((width.ceil() as u32, height.ceil() as u32))
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+fn draw_cached_bitmap(canvas: &dyn CanvasDevice, bitmap: &CachedBitmap, bbox: Rect) {
+    canvas.set_transform(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+    canvas.draw_image_with_offscreen_canvas(
+        &bitmap.canvas,
+        (bbox.left().0 - BITMAP_CACHE_PADDING) as f64,
+        (bbox.top().0 - BITMAP_CACHE_PADDING) as f64,
+    );
+}
+
+#[cfg(any(
+    feature = "bitmap_cache_word",
+    feature = "bitmap_cache_line",
+    feature = "bitmap_cache_paragraph"
+))]
+fn create_bitmap_canvas(
+    width: u32,
+    height: u32,
+) -> Option<(OffscreenCanvas, OffscreenCanvasRenderingContext2d)> {
+    let canvas = OffscreenCanvas::new(width, height).ok()?;
+    let context = canvas
+        .get_context("2d")
+        .ok()
+        .flatten()?
+        .dyn_into::<OffscreenCanvasRenderingContext2d>()
+        .ok()?;
+    Some((canvas, context))
+}
+
+#[cfg(feature = "bitmap_cache_word")]
+impl CanvasGroupElem {
+    async fn realize_group_bitmap(
+        &self,
+        rts: sk::Transform,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) -> bool {
+        if ts.kx != 0.0 || ts.ky != 0.0 {
+            return false;
+        }
+
+        let Some(bbox) = self.bbox_at(rts) else {
+            return false;
+        };
+        let Some((width, height)) = bitmap_dimensions(bbox) else {
+            return false;
+        };
+        let key = bitmap_cache_key(ts, bbox, width, height);
+
+        {
+            let cache = self.bitmap_cache.borrow();
+            if let Some(cache) = cache.as_ref().filter(|cache| cache.key == key) {
+                draw_cached_bitmap(canvas, &cache.bitmap, bbox);
+                return true;
+            }
+        }
+
+        let Some((bitmap_canvas, bitmap_context)) = create_bitmap_canvas(width, height) else {
+            return false;
+        };
+        let bitmap_device: &dyn CanvasDevice = &bitmap_context;
+        let shifted_ts = ts.post_translate(
+            -bbox.left().0 + BITMAP_CACHE_PADDING,
+            -bbox.top().0 + BITMAP_CACHE_PADDING,
+        );
+
+        {
+            let _scope = BitmapCacheScope::new();
+            self.realize_inner(shifted_ts, bitmap_device, ctx).await;
+        }
+
+        let bitmap = CachedBitmap {
+            canvas: bitmap_canvas,
+            width,
+            height,
+        };
+        draw_cached_bitmap(canvas, &bitmap, bbox);
+        *self.bitmap_cache.borrow_mut() = Some(GroupBitmapCache { key, bitmap });
+        true
+    }
+}
+
+#[cfg(any(feature = "bitmap_cache_line", feature = "bitmap_cache_paragraph"))]
+impl CanvasGroupElem {
+    async fn realize_inner_with_text_bitmap_spans(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) {
+        let mut idx = 0;
+        while idx < self.inner.len() {
+            if !is_text_group(&self.inner[idx].1) {
+                let (pos, sub_elem) = &self.inner[idx];
+                let sub_ts = ts.pre_translate(pos.x.0, pos.y.0);
+                if !ctx.render_window_intersects(sub_elem, sub_ts) {
+                    idx += 1;
+                    continue;
+                }
+                sub_elem.realize(sub_ts, canvas, ctx).await;
+                idx += 1;
+                continue;
+            }
+
+            let end = self.collect_text_bitmap_span(ts, idx);
+            if end > idx
+                && self
+                    .realize_text_bitmap_span(ts, idx, end, canvas, ctx)
+                    .await
+            {
+                idx = end;
+                continue;
+            }
+
+            let (pos, sub_elem) = &self.inner[idx];
+            let sub_ts = ts.pre_translate(pos.x.0, pos.y.0);
+            if !ctx.render_window_intersects(sub_elem, sub_ts) {
+                idx += 1;
+                continue;
+            }
+            sub_elem.realize(sub_ts, canvas, ctx).await;
+            idx += 1;
+        }
+    }
+
+    fn collect_text_bitmap_span(&self, ts: sk::Transform, start: usize) -> usize {
+        let Some(mut bbox) = self.span_bbox_at(ts, start, start + 1) else {
+            return start + 1;
+        };
+        let mut end = start + 1;
+
+        while end < self.inner.len() && is_text_group(&self.inner[end].1) {
+            let Some(next_bbox) = self.span_bbox_at(ts, end, end + 1) else {
+                break;
+            };
+
+            #[cfg(feature = "bitmap_cache_line")]
+            if !same_text_line(bbox, next_bbox) {
+                break;
+            }
+
+            #[cfg(feature = "bitmap_cache_paragraph")]
+            if !same_text_paragraph(bbox, next_bbox) {
+                break;
+            }
+
+            let candidate = bbox.union(&next_bbox);
+            if bitmap_dimensions(candidate).is_none() {
+                break;
+            }
+
+            bbox = candidate;
+            end += 1;
+        }
+
+        end
+    }
+
+    fn span_bbox_at(&self, ts: sk::Transform, start: usize, end: usize) -> Option<Rect> {
+        self.inner[start..end]
+            .iter()
+            .fold(None, |acc: Option<Rect>, (pos, elem)| {
+                let bbox = elem.bbox_at(ts.pre_translate(pos.x.0, pos.y.0))?;
+                Some(acc.map_or(bbox, |acc| acc.union(&bbox)))
+            })
+    }
+
+    async fn realize_text_bitmap_span(
+        &self,
+        ts: sk::Transform,
+        start: usize,
+        end: usize,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) -> bool {
+        if ts.kx != 0.0 || ts.ky != 0.0 {
+            return false;
+        }
+
+        let Some(bbox) = self.span_bbox_at(ts, start, end) else {
+            return false;
+        };
+        let Some((width, height)) = bitmap_dimensions(bbox) else {
+            return false;
+        };
+        let key = SpanBitmapCacheKey {
+            group: self as *const CanvasGroupElem as usize,
+            start,
+            end,
+            bitmap: bitmap_cache_key(ts, bbox, width, height),
+        };
+
+        if SPAN_BITMAP_CACHE.with(|cache| {
+            let cache = cache.borrow();
+            if let Some(bitmap) = cache.get(&key) {
+                draw_cached_bitmap(canvas, bitmap, bbox);
+                true
+            } else {
+                false
+            }
+        }) {
+            return true;
+        }
+
+        let Some((bitmap_canvas, bitmap_context)) = create_bitmap_canvas(width, height) else {
+            return false;
+        };
+        let bitmap_device: &dyn CanvasDevice = &bitmap_context;
+        let shifted_ts = ts.post_translate(
+            -bbox.left().0 + BITMAP_CACHE_PADDING,
+            -bbox.top().0 + BITMAP_CACHE_PADDING,
+        );
+
+        {
+            let _scope = BitmapCacheScope::new();
+            for (pos, sub_elem) in &self.inner[start..end] {
+                sub_elem
+                    .realize(
+                        shifted_ts.pre_translate(pos.x.0, pos.y.0),
+                        bitmap_device,
+                        ctx,
+                    )
+                    .await;
+            }
+        }
+
+        let bitmap = CachedBitmap {
+            canvas: bitmap_canvas,
+            width,
+            height,
+        };
+        draw_cached_bitmap(canvas, &bitmap, bbox);
+        SPAN_BITMAP_CACHE.with(|cache| {
+            cache.borrow_mut().insert(key, bitmap);
+        });
+        true
+    }
+}
+
+#[cfg(any(feature = "bitmap_cache_line", feature = "bitmap_cache_paragraph"))]
+fn is_text_group(node: &CanvasNode) -> bool {
+    matches!(
+        node.as_ref(),
+        CanvasElem::Group(group) if matches!(group.kind, GroupKind::Text)
+    )
+}
+
+#[cfg(feature = "bitmap_cache_line")]
+fn same_text_line(a: Rect, b: Rect) -> bool {
+    let top = a.top().0.max(b.top().0);
+    let bottom = a.bottom().0.min(b.bottom().0);
+    let overlap = bottom - top;
+    let min_height = a.height().0.min(b.height().0).max(1.0);
+    overlap > min_height * 0.5
+}
+
+#[cfg(feature = "bitmap_cache_paragraph")]
+fn same_text_paragraph(a: Rect, b: Rect) -> bool {
+    let vertical_gap = if b.top().0 > a.bottom().0 {
+        b.top().0 - a.bottom().0
+    } else if a.top().0 > b.bottom().0 {
+        a.top().0 - b.bottom().0
+    } else {
+        0.0
+    };
+    let line_height = a.height().0.max(b.height().0).max(1.0);
+    vertical_gap < line_height * 1.5
 }
 
 /// A reference to a canvas element with a clip path.
@@ -304,10 +816,15 @@ impl CanvasOp for CanvasClipElem {
         self.inner.prepare(ts)
     }
 
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        ctx: CanvasRenderContext,
+    ) {
         let _guard = self.realize_with(ts, canvas);
 
-        self.inner.realize(ts, canvas).await
+        self.inner.realize(ts, canvas, ctx).await
     }
 }
 
@@ -331,7 +848,12 @@ impl CanvasOp for CanvasPathElem {
         None::<EmptyFuture>
     }
 
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        _ctx: CanvasRenderContext,
+    ) {
         let _guard = CanvasStateGuard::new(canvas);
 
         if !set_transform(canvas, ts) {
@@ -380,18 +902,18 @@ impl CanvasOp for CanvasPathElem {
         let path = self.path.get_or_init(&self.path_data.d);
 
         if let Some(fill) = &self.fill {
-            if fill.fill_radial_path(canvas, ts, &path) {
+            if fill.fill_radial_path(canvas, ts, path) {
                 // Non-uniform radial gradients are drawn through a clipped
                 // paint transform to match SVG gradientTransform semantics.
-            } else if fill.fill_conic_path(canvas, ts, &path, true) {
+            } else if fill.fill_conic_path(canvas, ts, path, true) {
                 // Conic gradients fall back to segmented drawing when native
                 // canvas conics cannot represent the paint transform.
             } else {
                 fill.set_fill_style(canvas, ts);
                 if let Some(rule) = fill_rule {
-                    canvas.fill_with_path_2d_and_winding(&path, rule);
+                    canvas.fill_with_path_2d_and_winding(path, rule);
                 } else {
-                    canvas.fill_with_path_2d(&path);
+                    canvas.fill_with_path_2d(path);
                 }
             }
         }
@@ -399,7 +921,7 @@ impl CanvasOp for CanvasPathElem {
         if stroke_width.abs() > 1e-5 {
             if let Some(stroke) = &self.stroke {
                 stroke.set_stroke_style(canvas, ts);
-                canvas.stroke_with_path(&path);
+                canvas.stroke_with_path(path);
             }
         }
 
@@ -492,7 +1014,12 @@ impl CanvasOp for CanvasImageElem {
         Self::prepare_image(self.image_data.image.clone())
     }
 
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        _ctx: CanvasRenderContext,
+    ) {
         Self::draw_image(ts, canvas, &self.image_data).await
     }
 }
@@ -521,7 +1048,12 @@ impl CanvasOp for CanvasGlyphElem {
         }
     }
 
-    async fn realize(&self, ts: sk::Transform, canvas: &dyn CanvasDevice) {
+    async fn realize(
+        &self,
+        ts: sk::Transform,
+        canvas: &dyn CanvasDevice,
+        _ctx: CanvasRenderContext,
+    ) {
         if ts.sx == 0. || ts.sy == 0. {
             return;
         }
@@ -537,7 +1069,7 @@ impl CanvasOp for CanvasGlyphElem {
                 }
 
                 let path = self.path.get_or_init(&path.d);
-                if self.fill.fill_conic_path(canvas, ts, &path, false) {
+                if self.fill.fill_conic_path(canvas, ts, path, false) {
                     return;
                 }
 
@@ -545,7 +1077,7 @@ impl CanvasOp for CanvasGlyphElem {
                     return;
                 }
                 self.fill.set_fill_style(canvas, ts);
-                canvas.fill_with_path_2d(&path);
+                canvas.fill_with_path_2d(path);
             }
             #[cfg(feature = "rasterize_glyph")]
             FlatGlyphItem::Outline(path) => {

--- a/crates/conversion/vec2canvas/src/ops.rs
+++ b/crates/conversion/vec2canvas/src/ops.rs
@@ -1031,6 +1031,7 @@ pub struct CanvasGlyphElem {
     pub upem: Scalar,
     pub glyph_data: Arc<FlatGlyphItem>,
     pub path: CachedPath2d,
+    pub bbox: OnceCell<Option<Rect>>,
 }
 
 #[async_trait(?Send)]

--- a/crates/conversion/vec2dom/src/canvas_backend.rs
+++ b/crates/conversion/vec2dom/src/canvas_backend.rs
@@ -1,7 +1,9 @@
 use reflexo::error::prelude::*;
 use reflexo::vector::ir::{self, Module, Page, Point, Scalar};
 use reflexo::vector::vm::RenderVm;
-use reflexo_vec2canvas::{BBoxAt, CanvasElem, CanvasNode, CanvasOp, CanvasTask, ExportFeature};
+use reflexo_vec2canvas::{
+    BBoxAt, CanvasElem, CanvasNode, CanvasOp, CanvasRenderContext, CanvasTask, ExportFeature,
+};
 
 use crate::dom::*;
 
@@ -266,7 +268,11 @@ impl TypstElem {
                         self.is_canvas_painted = false;
                     }
                     (false, false) => {
-                        self.canvas.as_ref().unwrap().realize(ts, panel).await;
+                        self.canvas
+                            .as_ref()
+                            .unwrap()
+                            .realize(ts, panel, CanvasRenderContext::default())
+                            .await;
                         self.is_canvas_painted = true;
                         return;
                     }

--- a/crates/conversion/vec2dom/src/dom.rs
+++ b/crates/conversion/vec2dom/src/dom.rs
@@ -7,7 +7,7 @@ use std::{
 use reflexo::hash::Fingerprint;
 use reflexo::vector::ir::{self, Module, Page, Point, Scalar, Size, TextItem, TransformItem};
 use reflexo::{error::prelude::*, ImmutStr};
-use reflexo_vec2canvas::{CanvasElem, CanvasNode, CanvasOp, CanvasStateGuard};
+use reflexo_vec2canvas::{CanvasElem, CanvasNode, CanvasOp, CanvasRenderContext, CanvasStateGuard};
 use web_sys::{
     js_sys::Reflect,
     wasm_bindgen::{JsCast, JsValue},
@@ -560,7 +560,9 @@ impl DomPage {
                 });
 
                 let ts = tiny_skia::Transform::from_scale(ppp, ppp);
-                canvas_elem.realize(ts, &canvas_ctx).await;
+                canvas_elem
+                    .realize(ts, &canvas_ctx, CanvasRenderContext::default())
+                    .await;
             }
 
             let mut clip_rect = None;

--- a/packages/renderer/Cargo.toml
+++ b/packages/renderer/Cargo.toml
@@ -77,6 +77,9 @@ render_canvas = [
     "web-sys/HtmlImageElement",
     "web-sys/CanvasRenderingContext2d",
 ]
+bitmap_cache_word = ["reflexo-vec2canvas/bitmap_cache_word"]
+bitmap_cache_line = ["reflexo-vec2canvas/bitmap_cache_line"]
+bitmap_cache_paragraph = ["reflexo-vec2canvas/bitmap_cache_paragraph"]
 render_dom = ["dep:reflexo-vec2dom", "render_svg"]
 render_pdf = []
 render_svg = ["reflexo-typst/svg", "web-sys/HtmlDivElement"]

--- a/packages/renderer/src/lib.rs
+++ b/packages/renderer/src/lib.rs
@@ -13,6 +13,7 @@ use reflexo_typst::error::prelude::*;
 use rkyv::{Archive, Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+use reflexo_typst::vector::ir::{Axes, Rect, Scalar};
 use session::CreateSessionOptions;
 
 pub mod build_info {
@@ -88,6 +89,10 @@ pub struct RenderPageImageOptions {
     pub(crate) page_off: usize,
     pub(crate) cache_key: Option<String>,
     pub(crate) data_selection: Option<u32>,
+    pub(crate) window_lo_x: Option<f32>,
+    pub(crate) window_lo_y: Option<f32>,
+    pub(crate) window_hi_x: Option<f32>,
+    pub(crate) window_hi_y: Option<f32>,
 }
 
 #[wasm_bindgen]
@@ -100,6 +105,10 @@ impl RenderPageImageOptions {
             page_off: 0,
             cache_key: None,
             data_selection: None,
+            window_lo_x: None,
+            window_lo_y: None,
+            window_hi_x: None,
+            window_hi_y: None,
         }
     }
 
@@ -152,12 +161,59 @@ impl RenderPageImageOptions {
     pub fn set_data_selection(&mut self, data_selection: Option<u32>) {
         self.data_selection = data_selection;
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn window_lo_x(&self) -> Option<f32> {
+        self.window_lo_x
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_window_lo_x(&mut self, window_lo_x: Option<f32>) {
+        self.window_lo_x = window_lo_x;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn window_lo_y(&self) -> Option<f32> {
+        self.window_lo_y
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_window_lo_y(&mut self, window_lo_y: Option<f32>) {
+        self.window_lo_y = window_lo_y;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn window_hi_x(&self) -> Option<f32> {
+        self.window_hi_x
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_window_hi_x(&mut self, window_hi_x: Option<f32>) {
+        self.window_hi_x = window_hi_x;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn window_hi_y(&self) -> Option<f32> {
+        self.window_hi_y
+    }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_window_hi_y(&mut self, window_hi_y: Option<f32>) {
+        self.window_hi_y = window_hi_y;
+    }
 }
 
 impl RenderPageImageOptions {
     pub(crate) fn renders_canvas_body(&self) -> bool {
         let data_selection = self.data_selection.unwrap_or(u32::MAX);
         (data_selection & (1 << 0)) != 0
+    }
+
+    pub(crate) fn window_rect(&self) -> Option<Rect> {
+        Some(Rect {
+            lo: Axes::new(Scalar(self.window_lo_x?), Scalar(self.window_lo_y?)),
+            hi: Axes::new(Scalar(self.window_hi_x?), Scalar(self.window_hi_y?)),
+        })
     }
 }
 
@@ -239,7 +295,6 @@ impl TypstRenderer {
 pub(crate) mod worker;
 #[cfg(not(feature = "worker"))]
 pub mod canvas_stub {
-    #![allow(dead_code)]
     #![allow(unused_imports)]
 
     use js_sys::{Promise, Uint8Array};

--- a/packages/renderer/src/render/canvas.rs
+++ b/packages/renderer/src/render/canvas.rs
@@ -56,15 +56,6 @@ impl TypstRenderer {
         options: Option<RenderPageImageOptions>,
     ) -> Result<(Fingerprint, JsValue, Option<HashMap<String, f64>>)> {
         let opts = options.unwrap_or_default();
-        let rect_lo_x: f32 = -1.;
-        let rect_lo_y: f32 = -1.;
-        let rect_hi_x: f32 = 1e30;
-        let rect_hi_y: f32 = 1e30;
-        let rect = Rect {
-            lo: Axes::new(Scalar(rect_lo_x), Scalar(rect_lo_y)),
-            hi: Axes::new(Scalar(rect_hi_x), Scalar(rect_hi_y)),
-        };
-
         let mut kern = ses.client.lock().unwrap();
         let mut client = ses.canvas_kern.lock().unwrap();
 
@@ -95,6 +86,10 @@ impl TypstRenderer {
         let pages = t.pages(kern.module()).unwrap().pages();
 
         let page_num = opts.page_off;
+        let rect = opts.window_rect().unwrap_or(Rect {
+            lo: Axes::new(Scalar(-1.), Scalar(-1.)),
+            hi: Axes::new(Scalar(1e30), Scalar(1e30)),
+        });
         let page = if let Some(page) = pages.get(page_num) {
             page.clone()
         } else {

--- a/packages/typst.ts/src/options.render.mts
+++ b/packages/typst.ts/src/options.render.mts
@@ -133,6 +133,12 @@ export class RenderCanvasOptions {
    * The page offset to render.
    */
   pageOffset: number;
+
+  /**
+   * Render only the page-local rectangle. Coordinates are in Typst points.
+   */
+  window?: Rect;
+
   /**
    * The previous render state.
    */

--- a/packages/typst.ts/src/renderer.mts
+++ b/packages/typst.ts/src/renderer.mts
@@ -372,7 +372,6 @@ export interface TypstSvgRenderer {
   renderToSvg(options: RenderOptions<RenderToSvgOptions>): Promise<boolean>;
 }
 
-
 /**
  * The interface of Typst renderer.
  */
@@ -610,7 +609,7 @@ export class TypstRendererDriver {
   renderer: typst.TypstRenderer;
   rendererJs: typeof typst;
 
-  constructor() { }
+  constructor() {}
 
   async init(options?: Partial<InitOptions>): Promise<void> {
     this.rendererJs = await (options?.getWrapper?.() || import('@myriaddreamin/typst-ts-renderer'));
@@ -651,6 +650,12 @@ export class TypstRendererDriver {
     }
     if (options.cacheKey !== undefined) {
       rustOptions.cache_key = options.cacheKey;
+    }
+    if (options.window !== undefined) {
+      rustOptions.window_lo_x = options.window.lo.x;
+      rustOptions.window_lo_y = options.window.lo.y;
+      rustOptions.window_hi_x = options.window.hi.x;
+      rustOptions.window_hi_y = options.window.hi.y;
     }
     if (options.backgroundColor !== undefined) {
       rustOptions.background_color = options.backgroundColor;
@@ -823,7 +828,7 @@ export class TypstRendererDriver {
       if (options.pixelPerPt !== undefined && options.pixelPerPt <= 0) {
         throw new Error(
           'Invalid typst.RenderOptions.pixelPerPt, should be a positive number ' +
-          options.pixelPerPt,
+            options.pixelPerPt,
         );
       }
 
@@ -863,10 +868,10 @@ export class TypstRendererDriver {
         this,
         this.renderer.create_session(
           b &&
-          this.createOptionsToRust({
-            format: 'vector',
-            artifactContent: b,
-          }),
+            this.createOptionsToRust({
+              format: 'vector',
+              artifactContent: b,
+            }),
         ),
       ),
     );


### PR DESCRIPTION
- Add windowed canvas rendering support.
- Cull glyph rendering through cached glyph bounds.
- Fill only the requested window for partial renders.