### PR TITLE
fix(renderer): add canvas preview hit testing support

### DIFF
--- a/crates/conversion/vec2canvas/src/bounds.rs
+++ b/crates/conversion/vec2canvas/src/bounds.rs
@@ -11,6 +11,88 @@ pub trait BBoxAt {
     fn bbox_at(&self, ts: sk::Transform) -> Option<Rect>;
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct CanvasBound {
+    pub kind: &'static str,
+    pub rect: Rect,
+}
+
+pub fn hit_canvas_bound_at(
+    node: &CanvasNode,
+    ts: sk::Transform,
+    point: ir::Point,
+) -> Option<CanvasBound> {
+    hit_elem_bound_at(node, ts, point)
+}
+
+fn hit_elem_bound_at(
+    node: &CanvasNode,
+    ts: sk::Transform,
+    point: ir::Point,
+) -> Option<CanvasBound> {
+    match node.as_ref() {
+        CanvasElem::Group(group) => hit_group_bound_at(group, ts, point),
+        CanvasElem::Clip(clip) => hit_clip_bound_at(clip, ts, point),
+        CanvasElem::Path(path) => {
+            if path.fill.is_none() && path.stroke.is_none() {
+                return None;
+            }
+
+            let rect = path.bbox_at(ts)?;
+            rect_contains(rect, point).then_some(CanvasBound { kind: "path", rect })
+        }
+        CanvasElem::Image(image) => {
+            let rect = image.bbox_at(ts)?;
+            rect_contains(rect, point).then_some(CanvasBound {
+                kind: "image",
+                rect,
+            })
+        }
+        CanvasElem::Glyph(..) => None,
+    }
+}
+
+fn hit_group_bound_at(
+    group: &CanvasGroupElem,
+    ts: sk::Transform,
+    point: ir::Point,
+) -> Option<CanvasBound> {
+    if matches!(group.kind, GroupKind::Text) {
+        return None;
+    }
+
+    let ts = ts.pre_concat(*group.ts.as_ref());
+    for (pos, elem) in group.inner.iter().rev() {
+        let ts = ts.pre_translate(pos.x.0, pos.y.0);
+        if let Some(bound) = hit_elem_bound_at(elem, ts, point) {
+            return Some(bound);
+        }
+    }
+
+    None
+}
+
+fn hit_clip_bound_at(
+    clip: &CanvasClipElem,
+    ts: sk::Transform,
+    point: ir::Point,
+) -> Option<CanvasBound> {
+    if let Some(clip_rect) = clip.clip_bbox_at(ts) {
+        if !rect_contains(clip_rect, point) {
+            return None;
+        }
+    }
+
+    hit_elem_bound_at(&clip.inner, ts, point)
+}
+
+fn rect_contains(rect: Rect, point: ir::Point) -> bool {
+    point.x >= rect.left()
+        && point.x <= rect.right()
+        && point.y >= rect.top()
+        && point.y <= rect.bottom()
+}
+
 pub enum CanvasBBox {
     Static(Box<Rect>),
     Dynamic(Box<OnceCell<elsa::FrozenMap<ir::Transform, Box<Option<Rect>>>>>),

--- a/crates/conversion/vec2canvas/src/incr.rs
+++ b/crates/conversion/vec2canvas/src/incr.rs
@@ -13,8 +13,8 @@ use reflexo::{
 };
 
 use crate::{
-    set_transform, CanvasDevice, CanvasOp, CanvasPage, CanvasRenderContext, CanvasTask,
-    DefaultExportFeature,
+    hit_canvas_bound_at, set_transform, CanvasBound, CanvasDevice, CanvasOp, CanvasPage,
+    CanvasRenderContext, CanvasTask, DefaultExportFeature,
 };
 
 /// Prepared canvas resources that can be awaited after the document locks are
@@ -283,6 +283,27 @@ impl IncrCanvasDocClient {
         let s = self.vec2canvas.pixel_per_pt;
         let ts = sk::Transform::from_scale(s, s);
         self.vec2canvas.prepare_pages(indices, ts)
+    }
+
+    /// Hit tests non-text visual bounds on a page in page-space points.
+    pub fn hit_page_bound(
+        &mut self,
+        kern: &mut IncrDocClient,
+        idx: usize,
+        x: f32,
+        y: f32,
+    ) -> Result<Option<CanvasBound>> {
+        self.patch_delta(kern);
+
+        let Some(page) = self.vec2canvas.pages.get(idx) else {
+            Err(error_once!("Renderer.OutofPageRange", idx: idx))?
+        };
+
+        Ok(hit_canvas_bound_at(
+            &page.elem,
+            sk::Transform::identity(),
+            Point::new(Scalar(x), Scalar(y)),
+        ))
     }
 }
 

--- a/crates/conversion/vec2canvas/src/lib.rs
+++ b/crates/conversion/vec2canvas/src/lib.rs
@@ -11,7 +11,7 @@ mod paint;
 mod pixglyph_canvas;
 mod utils;
 
-pub use bounds::BBoxAt;
+pub use bounds::{hit_canvas_bound_at, BBoxAt, CanvasBound};
 pub use device::CanvasDevice;
 #[cfg(feature = "incremental")]
 pub use incr::*;

--- a/packages/renderer/Cargo.toml
+++ b/packages/renderer/Cargo.toml
@@ -93,7 +93,7 @@ worker = [
     "web-sys/WorkerType",
 ]
 
-web = ["render_canvas", "render_svg", "render_dom"]
+web = ["render_canvas", "render_svg", "render_dom", "worker"]
 
 debug_delta_update = []
 test_render_document = []

--- a/packages/renderer/src/render/canvas.rs
+++ b/packages/renderer/src/render/canvas.rs
@@ -4,7 +4,9 @@ use std::sync::OnceLock;
 use reflexo_typst::error::prelude::*;
 use reflexo_typst::hash::Fingerprint;
 use reflexo_typst::vector::ir::{Axes, Rect, Scalar};
-use reflexo_vec2canvas::{BrowserFontMetric, CanvasDevice, DefaultExportFeature, ExportFeature};
+use reflexo_vec2canvas::{
+    BrowserFontMetric, CanvasBound, CanvasDevice, DefaultExportFeature, ExportFeature,
+};
 use reflexo_vec2sema::SemaTask;
 use wasm_bindgen::prelude::*;
 use web_sys::{CanvasRenderingContext2d, OffscreenCanvasRenderingContext2d};
@@ -43,9 +45,52 @@ impl TypstRenderer {
         err.map_err(map_into_err::<JsValue, _>("Renderer.SetHtmlSemantics"))?;
         Ok(res.into())
     }
+
+    pub fn hit_canvas_page_bound(
+        &mut self,
+        ses: &RenderSession,
+        page_off: usize,
+        x: f32,
+        y: f32,
+    ) -> Result<JsValue> {
+        let mut kern = ses.client.lock().unwrap();
+        let mut client = ses.canvas_kern.lock().unwrap();
+
+        let Some(bound) = client.hit_page_bound(&mut kern, page_off, x, y)? else {
+            return Ok(JsValue::NULL);
+        };
+
+        canvas_bound_to_js(bound)
+    }
 }
 
 static FONT_METRICS: OnceLock<BrowserFontMetric> = OnceLock::new();
+
+fn canvas_bound_to_js(bound: CanvasBound) -> Result<JsValue> {
+    let rect = js_sys::Object::new();
+    set_js_number(&rect, "x", bound.rect.left().0 as f64)?;
+    set_js_number(&rect, "y", bound.rect.top().0 as f64)?;
+    set_js_number(&rect, "width", bound.rect.width().0 as f64)?;
+    set_js_number(&rect, "height", bound.rect.height().0 as f64)?;
+
+    let res = js_sys::Object::new();
+    set_js_string(&res, "kind", bound.kind)?;
+    js_sys::Reflect::set(&res, &"rect".into(), &rect)
+        .map_err(map_into_err::<JsValue, _>("Renderer.SetCanvasBoundRect"))?;
+    Ok(res.into())
+}
+
+fn set_js_number(obj: &js_sys::Object, key: &str, value: f64) -> Result<()> {
+    js_sys::Reflect::set(obj, &key.into(), &value.into())
+        .map_err(map_into_err::<JsValue, _>("Renderer.SetCanvasBoundNumber"))?;
+    Ok(())
+}
+
+fn set_js_string(obj: &js_sys::Object, key: &str, value: &str) -> Result<()> {
+    js_sys::Reflect::set(obj, &key.into(), &value.into())
+        .map_err(map_into_err::<JsValue, _>("Renderer.SetCanvasBoundString"))?;
+    Ok(())
+}
 
 impl TypstRenderer {
     #[allow(clippy::await_holding_lock)]

--- a/packages/renderer/src/render/canvas.rs
+++ b/packages/renderer/src/render/canvas.rs
@@ -22,7 +22,7 @@ impl TypstRenderer {
         options: Option<RenderPageImageOptions>,
     ) -> Result<JsValue> {
         let canvas = canvas.as_ref();
-        let canvas = if canvas == &JsValue::NULL {
+        let canvas = if canvas == &JsValue::NULL || canvas == &JsValue::UNDEFINED {
             None
         } else {
             Some(match canvas.dyn_ref::<CanvasRenderingContext2d>() {

--- a/packages/renderer/src/render/mod.rs
+++ b/packages/renderer/src/render/mod.rs
@@ -30,6 +30,16 @@ pub mod canvas_stub {
         ) -> Result<JsValue> {
             Err(error_once!("Renderer.CanvasFeatureNotEnabled"))
         }
+
+        pub fn hit_canvas_page_bound(
+            &mut self,
+            _ses: &RenderSession,
+            _page_off: usize,
+            _x: f32,
+            _y: f32,
+        ) -> Result<JsValue> {
+            Err(error_once!("Renderer.CanvasFeatureNotEnabled"))
+        }
     }
 }
 #[cfg(not(feature = "render_canvas"))]

--- a/packages/renderer/src/worker.rs
+++ b/packages/renderer/src/worker.rs
@@ -459,7 +459,7 @@ pub struct WorkerBridge {
     pub(crate) sessions: HashMap<i32, Arc<Mutex<RenderSession>>>,
     pub(crate) canvases: HashMap<i32, HashMap<usize, OffscreenCanvas>>,
     pub(crate) previous_promise: Option<Promise>,
-    pub(crate) sessions: i32,
+    pub(crate) session_counter: i32,
 }
 
 #[wasm_bindgen]
@@ -480,8 +480,8 @@ impl WorkerBridge {
         let res = match x {
             Request::CreateSession(opts) => {
                 let session = self.plugin.create_session(opts).unwrap();
-                let idx = self.sessions;
-                self.sessions += 1;
+                let idx = self.session_counter;
+                self.session_counter += 1;
                 #[allow(clippy::arc_with_non_send_sync)]
                 self.sessions.insert(idx, Arc::new(Mutex::new(session)));
                 Ok(JsValue::from_f64(idx as f64))
@@ -574,7 +574,7 @@ impl WorkerBridge {
             Request::SetBackgroundColor(ses, color) => {
                 let session = self.sessions.get(&ses).unwrap().clone();
                 let p = wasm_bindgen_futures::future_to_promise(async move {
-                    session.lock().unwrap().set_background_color(color);
+                    session.lock().unwrap().set_background_color(Some(color));
                     Ok(JsValue::NULL)
                 });
                 Err(p)
@@ -583,7 +583,7 @@ impl WorkerBridge {
             Request::SetPixelPerPt(ses, f) => {
                 let session = self.sessions.get(&ses).unwrap().clone();
                 let p = wasm_bindgen_futures::future_to_promise(async move {
-                    session.lock().unwrap().set_pixel_per_pt(f);
+                    session.lock().unwrap().set_pixel_per_pt(Some(f));
                     Ok(JsValue::NULL)
                 });
                 Err(p)

--- a/packages/typst.ts/src/internal.types.mts
+++ b/packages/typst.ts/src/internal.types.mts
@@ -43,6 +43,18 @@ export interface Rect {
   hi: Point;
 }
 
+export interface PageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CanvasPageBound {
+  kind: string;
+  rect: PageRect;
+}
+
 export type TransformMatrix = [number, number, number, number, number, number];
 
 //#region Semantic tokens: https://github.com/microsoft/vscode/issues/86415

--- a/packages/typst.ts/src/options.render.mts
+++ b/packages/typst.ts/src/options.render.mts
@@ -49,6 +49,26 @@ export interface RenderToCanvasOptions
 }
 
 /**
+ * The options for hit testing a non-text visual bound on a canvas page.
+ */
+export interface HitCanvasPageBoundOptions {
+  /**
+   * The page offset to hit test.
+   */
+  pageOffset: number;
+
+  /**
+   * The page-space x coordinate in Typst points.
+   */
+  x: number;
+
+  /**
+   * The page-space y coordinate in Typst points.
+   */
+  y: number;
+}
+
+/**
  * The options for mounting Typst document to specified container.
  * @property {HTMLElement} [container] - The container to render the Typst document.
  * @property {number} [pixelPerPt] - The pixel per point scale up the image, which is 2.5 by default and recommended.

--- a/packages/typst.ts/src/renderer.mts
+++ b/packages/typst.ts/src/renderer.mts
@@ -2,7 +2,13 @@
 import type * as typst from '@myriaddreamin/typst-ts-renderer';
 
 import type { InitOptions } from './options.init.mjs';
-import { PageInfo, RenderCanvasResult, TypstDefaultParams, kObject } from './internal.types.mjs';
+import {
+  CanvasPageBound,
+  PageInfo,
+  RenderCanvasResult,
+  TypstDefaultParams,
+  kObject,
+} from './internal.types.mjs';
 import {
   CreateSessionOptions,
   RenderToCanvasOptions,
@@ -14,6 +20,7 @@ import {
   RenderInSessionOptions,
   MountDomOptions,
   OffscreenRenderCanvasOptions,
+  HitCanvasPageBoundOptions,
 } from './options.render.mjs';
 import { RenderView } from './render/canvas/view.mjs';
 import { LazyWasmModule } from './wasm.mjs';
@@ -188,6 +195,16 @@ export class RenderSession {
    */
   renderCanvas(options: ContextedRenderOptions<RenderCanvasOptions>): Promise<RenderCanvasResult> {
     return this.plugin.renderCanvas({
+      renderSession: this,
+      ...options,
+    });
+  }
+
+  /**
+   * See {@link TypstRenderer#hitCanvasPageBound} for more details.
+   */
+  hitCanvasPageBound(options: HitCanvasPageBoundOptions): CanvasPageBound | undefined {
+    return this.plugin.hitCanvasPageBound({
       renderSession: this,
       ...options,
     });
@@ -404,6 +421,13 @@ export interface TypstRenderer extends TypstSvgRenderer {
    * Render a Typst document to canvas.
    */
   renderCanvas(options: RenderOptions<RenderCanvasOptions>): Promise<RenderCanvasResult>;
+
+  /**
+   * Hit test a non-text visual bound on a rendered canvas page.
+   */
+  hitCanvasPageBound(
+    options: RenderInSessionOptions<HitCanvasPageBoundOptions>,
+  ): CanvasPageBound | undefined;
 
   /**
    * Render a Typst document to canvas.
@@ -697,6 +721,18 @@ export class TypstRendererDriver {
         this.canvasOptionsToRust(options),
       );
     });
+  }
+
+  hitCanvasPageBound(
+    options: RenderInSessionOptions<HitCanvasPageBoundOptions>,
+  ): CanvasPageBound | undefined {
+    const result = (this.renderer as any).hit_canvas_page_bound(
+      options.renderSession[kObject],
+      options.pageOffset,
+      options.x,
+      options.y,
+    );
+    return result === null || result === undefined ? undefined : (result as CanvasPageBound);
   }
 
   // async renderPdf(artifactContent: string): Promise<Uint8Array> {


### PR DESCRIPTION
- Add dynamic canvas bound hit testing for preview interactions.
- Expose windowed canvas render options through typst.ts.
- Enable renderer worker support for web builds.